### PR TITLE
Fix parsing non existing properties

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -350,5 +350,42 @@ namespace nanoFramework.Json.Test
             Debug.WriteLine("double NaN Object Test Test succeeded");
             Debug.WriteLine("");
         }
+
+
+        [TestMethod]
+        public void Can_serialize_and_deserialize_twin_properties()
+        {
+
+            var testString = "{\"desired\":{\"TimeToSleep\":5,\"$version\":2},\"reported\":{\"Firmware\":\"nanoFramework\",\"TimeToSleep\":2,\"$version\":94}}";
+
+            var dserResult = (TwinProperties)JsonConvert.DeserializeObject(testString, typeof(TwinProperties));
+
+            Assert.NotNull(dserResult, "Deserialization returned a null object");
+
+            Debug.WriteLine("");
+        }
+
+        #region Test classes
+
+        public class TwinProperties
+        {
+            public Desired desired { get; set; }
+            public Reported reported { get; set; }
+        }
+
+        public class Desired
+        {
+            public int TimeToSleep { get; set; }
+        }
+
+        public class Reported
+        {
+            public string Firmware { get; set; }
+
+            public int TimeToSleep { get; set; }
+        }
+
+        #endregion
+
     }
     }

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -166,7 +166,8 @@ namespace nanoFramework.Json
                             memberPropGetMethod = rootType.GetMethod("get_" + memberProperty.Name);
                             if (memberPropGetMethod == null)
                             {
-                                throw new Exception($"PopulateObject() - failed to create memberType.  {rootType.Name}.GetMethod() is null");
+                                Debug.WriteLine($"PopulateObject() - failed to create memberType.  {rootType.Name}.GetMethod() is null. Possibly this property doesn't exist.");
+                                continue;
                             }
                             else
                             {
@@ -174,7 +175,7 @@ namespace nanoFramework.Json
                                 memberPropSetMethod = rootType.GetMethod("set_" + memberProperty.Name);
                                 if (memberType == null)
                                 {
-                                    throw new Exception($"PopulateObject() - failed to create memberType from {rootType.Name}.GetMethod ");
+                                    throw new Exception($"PopulateObject() - failed to get setter of memberType {rootType.Name}. Possibly this property doesn't have a setter.");
                                 }
                                 memberIsProperty = true;
                                 Debug.WriteLine($"{debugIndent}     memberType:  {memberType.Name} ");


### PR DESCRIPTION
## Description
- ParseObject now can deal with non existing properties.

## Motivation and Context
- Need to be able to parse Json strings whose values don't have a corresponding property in the target class.

## How Has This Been Tested?<!-- (if applicable) -->
- Added new unit test to cover this.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
