### PR TITLE
Improvements and fixes

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -558,6 +558,20 @@ namespace nanoFramework.Json.Test
         }
 
         [TestMethod]
+        public void CanDeserializeAzureTwinProperties_04()
+        {
+            TwinPayloadProperties twinPayload = (TwinPayloadProperties)JsonConvert.DeserializeObject(s_AzureTwinsJsonTestPayload, typeof(TwinPayloadProperties));
+
+            Assert.NotNull(twinPayload, "Deserialization returned a null object");
+
+            Assert.Equal(twinPayload.properties.desired.TimeToSleep, 30, "properties.desired.TimeToSleep doesn't match");
+            Assert.Equal(twinPayload.properties.reported._metadata.Count, 3, "properties.reported._metadata collection count doesn't match");
+            Assert.Equal(twinPayload.properties.desired._metadata.Count, 3, "properties.desired._metadata collection count doesn't match");
+
+            Debug.WriteLine("");
+        }
+
+        [TestMethod]
         public void CanDeserializeInvocationReceiveMessage_01()
         {
 

--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -501,14 +501,58 @@ namespace nanoFramework.Json.Test
         }
 
         [TestMethod]
-        public void CanSerializeAndDeserializeTwinProperties_01()
+        public void CanDeserializeAzureTwinProperties_01()
         {
-
             var testString = "{\"desired\":{\"TimeToSleep\":5,\"$version\":2},\"reported\":{\"Firmware\":\"nanoFramework\",\"TimeToSleep\":2,\"$version\":94}}";
 
-            var dserResult = (TwinProperties)JsonConvert.DeserializeObject(testString, typeof(TwinProperties));
+            var twinPayload = (TwinProperties)JsonConvert.DeserializeObject(testString, typeof(TwinProperties));
 
-            Assert.NotNull(dserResult, "Deserialization returned a null object");
+            Assert.NotNull(twinPayload, "Deserialization returned a null object");
+
+            Assert.Equal(twinPayload.desired.TimeToSleep, 5, "desired.TimeToSleep doesn't match");
+            Assert.Null(twinPayload.desired._metadata, "desired._metadata doesn't match");
+
+            Assert.Equal(twinPayload.reported.Firmware, "nanoFramework", "reported.Firmware doesn't match");
+            Assert.Equal(twinPayload.reported.TimeToSleep, 2, "reported.TimeToSleep doesn't match");
+            Assert.Null(twinPayload.reported._metadata, "reported._metadata doesn't match");
+
+            Debug.WriteLine("");
+        }
+        
+        [TestMethod]
+        public void CanDeserializeAzureTwinProperties_02()
+        {
+            TwinPayload twinPayload = (TwinPayload)JsonConvert.DeserializeObject(s_AzureTwinsJsonTestPayload, typeof(TwinPayload));
+
+            Assert.NotNull(twinPayload, "Deserialization returned a null object");
+
+            Assert.Equal(twinPayload.authenticationType, "sas", "authenticationType doesn't match");
+            Assert.Equal(twinPayload.statusUpdateTime.Ticks, DateTime.MinValue.Ticks, "statusUpdateTime doesn't match");
+            Assert.Equal(twinPayload.cloudToDeviceMessageCount, 0, "cloudToDeviceMessageCount doesn't match");
+            Assert.Equal(twinPayload.x509Thumbprint.Count, 2, "x509Thumbprint collection count doesn't match");
+            Assert.Equal(twinPayload.version, 381, "version doesn't match");
+            Assert.Equal(twinPayload.properties.desired.TimeToSleep, 30, "properties.desired.TimeToSleep doesn't match");
+            Assert.Equal(twinPayload.properties.reported._metadata.Count, 3, "properties.reported._metadata collection count doesn't match");
+            Assert.Equal(twinPayload.properties.desired._metadata.Count, 3, "properties.desired._metadata collection count doesn't match");
+
+            Debug.WriteLine("");
+        }
+
+        [TestMethod]
+        public void CanDeserializeAzureTwinProperties_03()
+        {
+            TwinPayload twinPayload = (TwinPayload)JsonConvert.DeserializeObject(s_AzureTwinsJsonTestPayload, typeof(TwinPayload));
+
+            Assert.NotNull(twinPayload, "Deserialization returned a null object");
+
+            Assert.Equal(twinPayload.authenticationType, "sas", "authenticationType doesn't match");
+            Assert.Equal(twinPayload.statusUpdateTime.Ticks, DateTime.MinValue.Ticks, "statusUpdateTime doesn't match");
+            Assert.Equal(twinPayload.cloudToDeviceMessageCount, 0, "cloudToDeviceMessageCount doesn't match");
+            Assert.Equal(twinPayload.x509Thumbprint.Count, 2, "x509Thumbprint collection count doesn't match");
+            Assert.Equal(twinPayload.version, 381, "version doesn't match");
+            Assert.Equal(twinPayload.properties.desired.TimeToSleep, 30, "properties.desired.TimeToSleep doesn't match");
+            Assert.Equal(twinPayload.properties.reported._metadata.Count, 3, "properties.reported._metadata collection count doesn't match");
+            Assert.Equal(twinPayload.properties.desired._metadata.Count, 3, "properties.desired._metadata collection count doesn't match");
 
             Debug.WriteLine("");
         }
@@ -560,15 +604,86 @@ namespace nanoFramework.Json.Test
 
         #region Test classes
 
+        private static string s_AzureTwinsJsonTestPayload = @"{
+    ""deviceId"": ""nanoDeepSleep"",
+    ""etag"": ""AAAAAAAAAAc="",
+    ""deviceEtag"": ""Njc2MzYzMTQ5"",
+    ""status"": ""enabled"",
+    ""statusUpdateTime"": ""0001-01-01T00:00:00Z"",
+    ""connectionState"": ""Disconnected"",
+    ""lastActivityTime"": ""2021-06-03T05:52:41.4683112Z"",
+    ""cloudToDeviceMessageCount"": 0,
+    ""authenticationType"": ""sas"",
+    ""x509Thumbprint"": {
+                ""primaryThumbprint"": null,
+        ""secondaryThumbprint"": null
+    },
+    ""modelId"": """",
+    ""version"": 381,
+    ""properties"": {
+                ""desired"": {
+                    ""TimeToSleep"": 30,
+            ""$metadata"": {
+                        ""$lastUpdated"": ""2021-06-03T05:37:11.8120413Z"",
+                ""$lastUpdatedVersion"": 7,
+                ""TimeToSleep"": {
+                            ""$lastUpdated"": ""2021-06-03T05:37:11.8120413Z"",
+                    ""$lastUpdatedVersion"": 7
+                }
+                    },
+            ""$version"": 7
+                },
+        ""reported"": {
+                    ""Firmware"": ""nanoFramework"",
+            ""TimeToSleep"": 30,
+            ""$metadata"": {
+                        ""$lastUpdated"": ""2021-06-03T05:52:41.1232797Z"",
+                ""Firmware"": {
+                            ""$lastUpdated"": ""2021-06-03T05:52:41.1232797Z""
+                },
+                ""TimeToSleep"": {
+                            ""$lastUpdated"": ""2021-06-03T05:52:41.1232797Z""
+                }
+                    },
+            ""$version"": 374
+        }
+            },
+    ""capabilities"": {
+                ""iotEdge"": false
+    }
+        }";
+
+        public class TwinPayload
+        {
+            public string deviceId { get; set; }
+            public string etag { get; set; }
+            public string status { get; set; }
+            public DateTime statusUpdateTime { get; set; }
+            public string connectionState { get; set; }
+            public DateTime lastActivityTime { get; set; }
+            public int cloudToDeviceMessageCount { get; set; }
+            public string authenticationType { get; set; }
+            public Hashtable x509Thumbprint { get; set; }
+            public string modelId { get; set; }
+            public int version { get; set; }
+            public TwinProperties properties { get; set; }
+        }
+
+
+        public class TwinPayloadProperties
+        {
+            public TwinProperties properties { get; set; }
+        }
+
         public class TwinProperties
         {
             public Desired desired { get; set; }
             public Reported reported { get; set; }
         }
-
         public class Desired
         {
             public int TimeToSleep { get; set; }
+            public Hashtable _metadata { get; set; }
         }
 
         public class Reported
@@ -576,7 +691,12 @@ namespace nanoFramework.Json.Test
             public string Firmware { get; set; }
 
             public int TimeToSleep { get; set; }
+
+            public Hashtable _metadata { get; set; }
+
+            public int _version { get; set; }
         }
+
 
         public class InvocationReceiveMessage
         {

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -1160,23 +1160,32 @@ namespace nanoFramework.Json
                                     //Debug.Assert(ch == openQuote);
 
                                     var stringValue = sb.ToString();
-                                    DateTime dtValue = DateTime.MinValue;
+                                    DateTime dtValue = DateTime.MaxValue;
 
                                     // check if this could be a DateTime value
                                     // min lenght is 18 for Java format: "Date(628318530718)": 18
 
                                     if (stringValue.Length >= 18)
                                     {
-                                        try
+                                        // check for special case of "null" date
+                                        if(stringValue == "0001-01-01T00:00:00Z")
                                         {
-                                            dtValue = DateTimeExtensions.FromIso8601(stringValue);
-                                        }
-                                        catch
-                                        {
-                                            // intended, to catch failed conversion attempt
+                                            dtValue = DateTime.MinValue;
                                         }
 
-                                        if (dtValue == DateTime.MinValue)
+                                        if (dtValue == DateTime.MaxValue)
+                                        {
+                                            try
+                                            {
+                                                dtValue = DateTimeExtensions.FromIso8601(stringValue);
+                                            }
+                                            catch
+                                            {
+                                                // intended, to catch failed conversion attempt
+                                            }
+                                        }
+
+                                        if (dtValue == DateTime.MaxValue)
                                         {
                                             try
                                             {
@@ -1188,7 +1197,7 @@ namespace nanoFramework.Json
                                             }
                                         }
 
-                                        if (dtValue == DateTime.MinValue)
+                                        if (dtValue == DateTime.MaxValue)
                                         {
                                             try
                                             {
@@ -1200,7 +1209,7 @@ namespace nanoFramework.Json
                                             }
                                         }
 
-                                        if (dtValue != DateTime.MinValue)
+                                        if (dtValue != DateTime.MaxValue)
                                         {
                                             return new LexToken() { TType = TokenType.Date, TValue = stringValue };
                                         }

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -202,9 +202,9 @@ namespace nanoFramework.Json
                         
                         var memberProperty = (JsonPropertyAttribute)m;
                         
-                        Debug.WriteLine($"{debugIndent}     memberProperty.Name:  {memberProperty?.Name ?? "null"} ");
+                        Debug.WriteLine($"{debugIndent}     memberProperty.Name:  {memberProperty.Name ?? "null"} ");
 
-                        string memberPropertyName = memberProperty?.Name;
+                        string memberPropertyName = memberProperty.Name;
 
                         // workaround for for property names that start with '$' like Azure Twins
                         if (memberPropertyName[0] == '$')

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -281,15 +281,15 @@ namespace nanoFramework.Json
 
                                 foreach (JsonPropertyAttribute v in ((JsonObjectAttribute)memberProperty.Value).Members)
                                 {
-                                    if (v.Value is JsonValue)
+                                    if (v.Value is JsonValue jsonValue)
                                     {
-                                        table.Add(v.Name, ((JsonValue)v.Value).Value);
+                                        table.Add(v.Name, (jsonValue).Value);
                                     }
-                                    else if (v.Value is JsonObjectAttribute)
+                                    else if (v.Value is JsonObjectAttribute jsonObjectAttribute)
                                     {
-                                        table.Add(v.Name, PopulateHashtable(v.Value));
+                                        table.Add(v.Name, PopulateHashtable(jsonObjectAttribute));
                                     }
-                                    else if (v.Value is JsonArrayAttribute)
+                                    else if (v.Value is JsonArrayAttribute jsonArrayAttribute)
                                     {
                                         throw new NotImplementedException();
                                     }
@@ -802,12 +802,12 @@ namespace nanoFramework.Json
 
                         mainTable.Add(memberProperty.Name, ((JsonValue)memberProperty.Value).Value);
                     }
-                    else if (memberProperty.Value is JsonArrayAttribute)
+                    else if (memberProperty.Value is JsonArrayAttribute jsonArrayAttribute)
                     {
                         Debug.WriteLine($"{debugIndent}     memberProperty.Value is a JArray");
 
                         // Create a JArray (memberValueArray) to hold the contents of memberProperty.Value 
-                        var memberValueArray = (JsonArrayAttribute)memberProperty.Value;
+                        var memberValueArray = jsonArrayAttribute;
 
                         // Create a temporary ArrayList memberValueArrayList - populate this as the memberItems are parsed
                         var memberValueArrayList = new ArrayList();
@@ -819,11 +819,11 @@ namespace nanoFramework.Json
 
                         foreach (JsonToken item in memberItems)
                         {
-                            if (item is JsonValue)
+                            if (item is JsonValue jsonValue)
                             {
-                                memberValueArrayList.Add(((JsonValue)item).Value);
+                                memberValueArrayList.Add((jsonValue).Value);
                             }
-                            else if (item is JsonToken)
+                            else if (item is JsonToken jsonToken)
                             {
                                 throw new NotImplementedException();
                             }
@@ -864,11 +864,9 @@ namespace nanoFramework.Json
             // Process all members for this rootObject
             Debug.WriteLine($"{debugIndent} Entering rootObject.Members loop ");
 
-            if (rootToken is JsonObjectAttribute)
+            if (rootToken is JsonObjectAttribute rootTokenObjectAttribute)
             {
-                var rootObject = (JsonObjectAttribute)rootToken;
-
-                foreach (var m in rootObject.Members)
+                foreach (var m in rootTokenObjectAttribute.Members)
                 {
                     Debug.WriteLine($"{debugIndent} Process rootObject.Member");
 
@@ -884,7 +882,7 @@ namespace nanoFramework.Json
                     Debug.WriteLine($"{debugIndent}     memberProperty.Name:  {memberProperty?.Name ?? "null"} ");
 
                     // Process the member based on JObject, JValue, or JArray
-                    if (memberProperty.Value is JsonObjectAttribute)
+                    if (memberProperty.Value is JsonObjectAttribute memberPropertyValue)
                     {
                         // Call PopulateObject() for this member - i.e. recursion
                         Debug.WriteLine($"{debugIndent}     memberProperty.Value is JObject");
@@ -893,27 +891,27 @@ namespace nanoFramework.Json
 
                         Debug.WriteLine($"{debugIndent}     successfully initialized member {memberProperty.Name} to memberObject");
                     }
-                    else if (memberProperty.Value is JsonValue)
+                    else if (memberProperty.Value is JsonValue memberPropertyJsonValue)
                     {
-                        if (memberProperty.Value is JsonValue)
+                        if (memberPropertyJsonValue.Value is JsonValue jsonValue)
                         {
-                            result.Add(memberProperty.Name, ((JsonValue)memberProperty.Value).Value);
+                            result.Add(memberProperty.Name, jsonValue.Value);
                         }
-                        else if (memberProperty.Value is JsonObjectAttribute)
+                        else if (memberPropertyJsonValue.Value is JsonObjectAttribute jsonObjectAttribute)
                         {
-                            result.Add(memberProperty.Name, PopulateHashtable((JsonObjectAttribute)memberProperty.Value));
+                            result.Add(memberProperty.Name, PopulateHashtable(jsonObjectAttribute));
                         }
-                        else if (memberProperty.Value is JsonArrayAttribute)
+                        else if (memberProperty.Value is JsonArrayAttribute jsonArrayAttribute)
                         {
                             throw new NotImplementedException();
                         }
                     }
-                    else if (memberProperty.Value is JsonArrayAttribute)
+                    else if (memberProperty.Value is JsonArrayAttribute jsonArrayAttribute)
                     {
                         Debug.WriteLine($"{debugIndent}     memberProperty.Value is a JArray");
 
                         // Create a JArray (memberValueArray) to hold the contents of memberProperty.Value 
-                        var memberValueArray = (JsonArrayAttribute)memberProperty.Value;
+                        var memberValueArray = jsonArrayAttribute;
 
                         // Create a temporary ArrayList memberValueArrayList - populate this as the memberItems are parsed
                         var memberValueArrayList = new ArrayList();
@@ -925,11 +923,11 @@ namespace nanoFramework.Json
 
                         foreach (JsonToken item in memberItems)
                         {
-                            if (item is JsonValue)
+                            if (item is JsonValue jsonValue)
                             {
-                                memberValueArrayList.Add(((JsonValue)item).Value);
+                                memberValueArrayList.Add(jsonValue);
                             }
-                            else if (item is JsonToken)
+                            else if (item is JsonToken jsonToken)
                             {
                                 throw new NotImplementedException();
                             }

--- a/nanoFramework.Json/JsonValue.cs
+++ b/nanoFramework.Json/JsonValue.cs
@@ -18,18 +18,27 @@ namespace nanoFramework.Json
 		{
 			if (isDateTime)
 			{
-				DateTime dtValue = DateTime.MinValue;
-
-				try
+				DateTime dtValue = DateTime.MaxValue;
+				
+				// check for special case of "null" date
+				if ((string)value == "0001-01-01T00:00:00Z")
 				{
-					dtValue = DateTimeExtensions.FromIso8601((string)value);
-				}
-				catch
-				{
-					// intended, to catch failed conversion attempt
+					dtValue = DateTime.MinValue;
 				}
 
-				if (dtValue == DateTime.MinValue)
+				if (dtValue == DateTime.MaxValue)
+				{
+					try
+					{
+						dtValue = DateTimeExtensions.FromIso8601((string)value);
+					}
+					catch
+					{
+						// intended, to catch failed conversion attempt
+					}
+				}
+
+				if (dtValue == DateTime.MaxValue)
 				{
 					try
 					{
@@ -41,7 +50,7 @@ namespace nanoFramework.Json
 					}
 				}
 
-				if (dtValue == DateTime.MinValue)
+				if (dtValue == DateTime.MaxValue)
 				{
 					try
 					{
@@ -53,7 +62,7 @@ namespace nanoFramework.Json
 					}
 				}
 
-				if (dtValue != DateTime.MinValue)
+				if (dtValue != DateTime.MaxValue)
 				{
 					Value = dtValue;
 				}

--- a/nanoFramework.Json/TimeExtensions.cs
+++ b/nanoFramework.Json/TimeExtensions.cs
@@ -100,7 +100,14 @@ namespace nanoFramework.Json
 			string second = (parts.Length > 5) ? parts[5] : "0";
 			string ms = (parts.Length > 6) ? parts[6] : "0";
 
-			DateTime dt = new DateTime(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day), Convert.ToInt32(hour), Convert.ToInt32(minute), Convert.ToInt32(second), Convert.ToInt32(ms));
+			// sanity check for bad milliseconds format
+			int milliseconds = Convert.ToInt32(ms);
+			if(milliseconds > 999)
+            {
+				milliseconds = 999;
+			}
+
+			DateTime dt = new DateTime(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day), Convert.ToInt32(hour), Convert.ToInt32(minute), Convert.ToInt32(second), milliseconds);
 
 			if (utc)
 			{


### PR DESCRIPTION
## Description
- Fixes with DateTime processing.
- Can handle 0001-01-01T00:00:00Z as the "null" value for DateTime.
- Can handle wrong encoded data from Azure Twins.
- Add workaround for Azure Twins properties starting with $
- Tries to find a property whose name starts with a _ instead.
- Update Unit Tests to cover these.
- Add new test classes to cover this.
- Improve handling of nested hastables.

## Motivation and Context
- Need to properly parse Azure Twins json payload.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
