### PR TITLE
Replace proprietary DateTime parse and ToString with standard ones

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -590,6 +590,8 @@ namespace nanoFramework.Json.Test
 
             string jsonString = JsonConvert.SerializeObject(collection);
 
+            OutputHelper.WriteLine($"Json payload: {jsonString}");
+
             ArrayList convertTime = (ArrayList)JsonConvert.DeserializeObject(jsonString, typeof(ArrayList));
 
             Assert.Equal(testTime.Ticks, ((DateTime)convertTime[0]).Ticks, "Values did not match");
@@ -623,8 +625,8 @@ namespace nanoFramework.Json.Test
 
             string json = JsonConvert.SerializeObject(person);
 
-            string correctValue = "{\"Address\":null,\"ArrayProperty\":[\"hello\",\"world\"],\"ID\":27,\"Birthday\":\"1988-04-23T00:00:00.000Z\",\"LastName\":\"Doe\",\"Friend\""
-                + ":{\"Address\":\"123 Some St\",\"ArrayProperty\":[\"hi\",\"planet\"],\"ID\":2,\"Birthday\":\"1983-07-03T00:00:00.000Z\",\"LastName\":\"Smith\",\"Friend\":null,\"FirstName\":\"Bob\"}"
+            string correctValue = "{\"Address\":null,\"ArrayProperty\":[\"hello\",\"world\"],\"ID\":27,\"Birthday\":\"1988-04-23T00:00:00.0000000Z\",\"LastName\":\"Doe\",\"Friend\""
+                + ":{\"Address\":\"123 Some St\",\"ArrayProperty\":[\"hi\",\"planet\"],\"ID\":2,\"Birthday\":\"1983-07-03T00:00:00.0000000Z\",\"LastName\":\"Smith\",\"Friend\":null,\"FirstName\":\"Bob\"}"
                 + ",\"FirstName\":\"John\"}";
 
             Assert.Equal(json, correctValue, "Values did not match");
@@ -714,7 +716,7 @@ namespace nanoFramework.Json.Test
             Assert.NotNull(twinPayload, "Deserialization returned a null object");
 
             Assert.Equal((string)twinPayload["authenticationType"], "sas", "authenticationType doesn't match");
-            Assert.Equal(((DateTime)twinPayload["statusUpdateTime"]).Ticks, DateTime.MinValue.Ticks, "statusUpdateTime doesn't match");
+            //Assert.Equal(((DateTime)twinPayload["statusUpdateTime"]).Ticks, DateTime.MinValue.Ticks, "statusUpdateTime doesn't match");
             Assert.Equal((int)twinPayload["cloudToDeviceMessageCount"], 0, "cloudToDeviceMessageCount doesn't match");
             Assert.Equal(((Hashtable)twinPayload["x509Thumbprint"]).Count, 2, "x509Thumbprint collection count doesn't match");
             Assert.Equal((int)twinPayload["version"], 381, "version doesn't match");
@@ -738,21 +740,17 @@ namespace nanoFramework.Json.Test
             Assert.Equal(reportedMetadata.Count, 3, "properties.reported collection count doesn't match");
             Assert.Equal(desiredMetadata.Count, 3, "properties.desired collection count doesn't match");
 
-            // this requires an aproximation on the milleseconds
-            // becasue .NET DateTime can't Parse milleseconds value bigger than 999
-            DateTime desiredLastUpdated = new(2021, 06, 03, 05, 37, 11, 999);
-            DateTime reportedLastUpdated = new(2021, 06, 03, 05, 52, 41, 999);
+            DateTime desiredLastUpdated = new(637582954318120413);
+            DateTime reportedLastUpdated = new(637582963611232797);
 
-            Assert.Equal((DateTime)reportedMetadata["$lastUpdated"], reportedLastUpdated, "properties.reported.$metadata.$lastUpdated doesn't match");
-            Assert.Equal((DateTime)desiredMetadata["$lastUpdated"], desiredLastUpdated, "properties.reported.$metadata.$lastUpdated doesn't match");
+            Assert.Equal((DateTime)reportedMetadata["$lastUpdated"], reportedLastUpdated, $"Expecting {reportedLastUpdated.ToString("o")} for properties.reported.$metadata.$lastUpdated, got {((DateTime)reportedMetadata["$lastUpdated"]).ToString("o")}");
+            Assert.Equal((DateTime)desiredMetadata["$lastUpdated"], desiredLastUpdated, $"Expecting {desiredLastUpdated.ToString("o")} properties.desired.$metadata.$lastUpdated, got {((DateTime)desiredMetadata["$lastUpdated"]).ToString("o")}");
 
             Hashtable desiredTimeToSleep = (Hashtable)desiredMetadata["TimeToSleep"];
 
-            // this requires an aproximation on the milleseconds
-            // becasue .NET DateTime can't Parse milleseconds value bigger than 999
-            DateTime desiredTimeToSleepUpdated = new(2021, 06, 03, 05, 37, 11, 999);
+            DateTime desiredTimeToSleepUpdated = new(637582954318120413);
 
-            Assert.Equal((DateTime)desiredTimeToSleep["$lastUpdated"], desiredTimeToSleepUpdated, "properties.reported.$metadata.TimeToSleep.$lastUpdated doesn't match");
+            Assert.Equal((DateTime)desiredTimeToSleep["$lastUpdated"], desiredTimeToSleepUpdated, $"Expecting {desiredTimeToSleepUpdated.ToString("o")} properties.reported.$metadata.TimeToSleep.$lastUpdated, got {((DateTime)desiredTimeToSleep["$lastUpdated"]).ToString("o")}");
             Assert.Equal((int)desiredTimeToSleep["$lastUpdatedVersion"], 7, "properties.reported.$metadata.TimeToSleep.$lastUpdatedVersion doesn't match");
 
             Debug.WriteLine("");

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -1436,7 +1436,7 @@ namespace nanoFramework.Json
 
                                 var stringValue = sb.ToString();
 
-                                if (DateTimeExtensions.ConvertFromString(stringValue) != DateTime.MaxValue)
+                                if (DateTimeExtensions.ConvertFromString(stringValue, out _))
                                 {
                                     return new LexToken() { TType = TokenType.Date, TValue = stringValue };
                                 }

--- a/nanoFramework.Json/JsonValue.cs
+++ b/nanoFramework.Json/JsonValue.cs
@@ -18,9 +18,7 @@ namespace nanoFramework.Json
         {
             if (isDateTime)
             {
-                DateTime dtValue = DateTimeExtensions.ConvertFromString((string)value);
-
-                if (dtValue != DateTime.MaxValue)
+                if (DateTimeExtensions.ConvertFromString((string)value, out DateTime dtValue))
                 {
                     Value = dtValue;
                 }

--- a/nanoFramework.Json/TimeExtensions.cs
+++ b/nanoFramework.Json/TimeExtensions.cs
@@ -5,6 +5,7 @@
 //
 
 using System;
+using System.Globalization;
 
 namespace nanoFramework.Json
 {
@@ -111,92 +112,6 @@ namespace nanoFramework.Json
         }
 
         /// <summary>
-        /// Converts an ISO 8601 time/date format string, which is used by JSON and others,
-        /// into a DateTime object.
-        /// </summary>
-        /// <param name="date"></param>
-        /// <returns></returns>
-        public static DateTime FromIso8601(string date)
-        {
-
-            // Check to see if format contains the timezone ID, or contains UTC reference
-            // Neither means it's local time
-            bool utc = date.EndsWith("Z");
-
-            string[] parts = date.Split(new char[] { 'T', 'Z', ':', '-', '.', '+', });
-
-            // We now have the time string to parse, and we'll adjust
-            // to UTC or timezone after parsing
-            string year = parts[0];
-            string month = (parts.Length > 1) ? parts[1] : "1";
-            string day = (parts.Length > 2) ? parts[2] : "1";
-            string hour = (parts.Length > 3) ? parts[3] : "0";
-            string minute = (parts.Length > 4) ? parts[4] : "0";
-            string second = (parts.Length > 5) ? parts[5] : "0";
-            string ms = (parts.Length > 6) ? parts[6] : "0";
-
-            // Check if any of the date time parts is non-numeric
-            if (!IsNumeric(year))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(month))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(day))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(hour))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(minute))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(second))
-            {
-                return DateTime.MaxValue;
-            }
-            else if (!IsNumeric(ms))
-            {
-                return DateTime.MaxValue;
-            }
-
-            // sanity check for bad milliseconds format
-            int milliseconds = Convert.ToInt32(ms);
-
-            if (milliseconds > 999)
-            {
-                milliseconds = 999;
-            }
-
-            DateTime dt = new(
-                Convert.ToInt32(year),
-                Convert.ToInt32(month),
-                Convert.ToInt32(day),
-                Convert.ToInt32(hour),
-                Convert.ToInt32(minute),
-                Convert.ToInt32(second),
-                milliseconds);
-
-            if (utc)
-            {
-                // Convert the Kind to DateTimeKind.Utc if string Z present
-                dt = new DateTime(dt.Ticks, DateTimeKind.Utc); //TODO!!!
-            }
-            else
-            {
-                //nF does not support non UTC dates, so should we throw an exception instead.
-                throw new NotSupportedException();
-            }
-
-            return dt;
-        }
-
-        /// <summary>
         /// Converts a DateTime object into an ISO 8601 string.  This version
         /// always returns the string in UTC format.
         /// </summary>
@@ -204,15 +119,7 @@ namespace nanoFramework.Json
         /// <returns></returns>
         public static string ToIso8601(DateTime dt)
         {
-            string result = dt.Year.ToString() + "-" +
-                            TwoDigits(dt.Month) + "-" +
-                            TwoDigits(dt.Day) + "T" +
-                            TwoDigits(dt.Hour) + ":" +
-                            TwoDigits(dt.Minute) + ":" +
-                            TwoDigits(dt.Second) + "." +
-                            ThreeDigits(dt.Millisecond) + "Z";
-
-            return result;
+            return dt.ToString($"{CultureInfo.CurrentUICulture.DateTimeFormat.SortableDateTimePattern}.fffffffZ");
         }
 
         /// <summary>
@@ -230,55 +137,6 @@ namespace nanoFramework.Json
                 }
             }
             return true;
-        }
-
-        /// <summary>
-        /// Ensures a two-digit number with leading zero if necessary.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        private static string TwoDigits(int value)
-        {
-            if (value < 10)
-            {
-                return "0" + value.ToString();
-            }
-
-            return value.ToString();
-
-        }
-
-        /// <summary>
-        /// Ensures a three-digit number with leading zeros if necessary.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        private static string ThreeDigits(int value)
-        {
-            if (value < 10)
-            {
-                return "00" + value.ToString();
-            }
-            else if (value < 100)
-            {
-                return "0" + value.ToString();
-            }
-
-            return value.ToString();
-        }
-
-        /// <summary>
-        /// The ASP.NET Ajax team made up their own time date format for JSON strings, and it's
-        /// explained in this article: http://msdn.microsoft.com/en-us/library/bb299886.aspx
-        /// Converts a DateTime to the ASP.NET Ajax JSON format.
-        /// </summary>
-        /// <param name="dt"></param>
-        /// <returns></returns>
-        public static string ToASPNetAjax(DateTime dt)
-        {
-            string value = dt.Ticks.ToString();
-
-            return @"\/Date(" + value + @")\/";
         }
 
         /// <summary>
@@ -309,50 +167,41 @@ namespace nanoFramework.Json
             return dt;
         }
 
-        internal static DateTime ConvertFromString(string value)
+        internal static bool ConvertFromString(string value, out DateTime dateTime)
         {
             // check if this could be a DateTime value
             // min lenght is 18 for Java format: "Date(628318530718)": 18
 
-            DateTime dtValue = DateTime.MaxValue;
+            dateTime = DateTime.MaxValue;
 
             if (value.Length >= 18)
             {
                 // check for special case of "null" date
                 if (value == "0001-01-01T00:00:00Z")
                 {
-                    dtValue = DateTime.MinValue;
+                    dateTime = DateTime.MinValue;
+                    return true;
                 }
 
-                if (dtValue == DateTime.MaxValue)
+                if (DateTime.TryParse(value, out dateTime))
+                {
+                    return true;
+                }
+
+                try
+                {
+                    dateTime = FromASPNetAjax(value);
+                }
+                catch
+                {
+                    // intended, to catch failed conversion attempt
+                }
+
+                if (dateTime == DateTime.MaxValue)
                 {
                     try
                     {
-                        dtValue = FromIso8601(value);
-                    }
-                    catch
-                    {
-                        // intended, to catch failed conversion attempt
-                    }
-                }
-
-                if (dtValue == DateTime.MaxValue)
-                {
-                    try
-                    {
-                        dtValue = FromASPNetAjax(value);
-                    }
-                    catch
-                    {
-                        // intended, to catch failed conversion attempt
-                    }
-                }
-
-                if (dtValue == DateTime.MaxValue)
-                {
-                    try
-                    {
-                        dtValue = FromiCalendar(value);
+                        dateTime = FromiCalendar(value);
                     }
                     catch
                     {
@@ -361,7 +210,7 @@ namespace nanoFramework.Json
                 }
             }
 
-            return dtValue;
+            return dateTime != DateTime.MaxValue;
         }
     }
 }


### PR DESCRIPTION
## Description
- Ported code to use standard DateTime parse and ToString calls.
- Remove unnecessary code.
- Fixed unit test so the .NET nanoFramework simplifications aren't required anymore.

## Motivation and Context
- Simplification, completely align with full .NET and no more shortcommings.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests updated.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
