### PR TITLE
Add support to deserialize & serialize TimeSpan

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -37,6 +37,17 @@ namespace nanoFramework.Json.Test
         public DateTime FixedTimestamp { get; set; }
     }
 
+    public class JsonTestClassTimespan
+    {
+        public TimeSpan Duration1 { get; set; } = TimeSpan.FromMinutes(69);
+        public TimeSpan Duration2 { get; set; }
+        public TimeSpan Duration3 { get; set; }
+        public TimeSpan Duration4 { get; set; }
+        public TimeSpan Duration5 { get; set; }
+        public int DummyValue1 { get; set; } = -999;
+        public uint DummyValue2 { get; set; } = 777;
+    }
+
     public class JsonTestClassComplex
     {
         public int aInteger { get; set; }
@@ -273,6 +284,43 @@ namespace nanoFramework.Json.Test
             Assert.Equal(timestampTests.Timestamp.ToString(), dserResult.Timestamp.ToString()); //cannot handle DateTime, so use ToString()
 
             Debug.WriteLine("Can_serialize_deserialize_timestamp() - Finished - test succeeded.");
+            Debug.WriteLine("");
+        }
+
+        [TestMethod]
+        public void Can_serialize_deserialize_timespan()
+        {
+            Debug.WriteLine("Can_serialize_deserialize_timespan() - Starting test...");
+
+            var randomValue = new Random();
+
+            var timeSpanTests = new JsonTestClassTimespan()
+            {
+                Duration2 = TimeSpan.FromSeconds(randomValue.Next(59)),
+                Duration3 = TimeSpan.FromMilliseconds(randomValue.Next(999)),
+                Duration4 = TimeSpan.FromHours(randomValue.Next(99)),
+                Duration5 = TimeSpan.FromDays(randomValue.Next(999)),
+            };
+
+            Debug.WriteLine($"Fixed timespan used for test = {timeSpanTests.Duration1}");
+            Debug.WriteLine($"variable timespan 2 used for test = {timeSpanTests.Duration2}");
+            Debug.WriteLine($"variable timespan 3 used for test = {timeSpanTests.Duration3}");
+            Debug.WriteLine($"variable timespan 4 used for test = {timeSpanTests.Duration4}");
+            Debug.WriteLine($"variable timespan 5 used for test = {timeSpanTests.Duration5}");
+
+            var result = JsonConvert.SerializeObject(timeSpanTests);
+            Debug.WriteLine($"Serialized class: {result}");
+
+            var dserResult = (JsonTestClassTimespan)JsonConvert.DeserializeObject(result, typeof(JsonTestClassTimespan));
+            Debug.WriteLine($"After Type deserialization: {dserResult}");
+
+            Assert.Equal(timeSpanTests.Duration1.ToString(), dserResult.Duration1.ToString(), $"wrong value for Duration1, expected 1:09:00, got {dserResult.Duration1.ToString()}");
+            Assert.Equal(timeSpanTests.Duration2.Ticks.ToString(), dserResult.Duration2.Ticks.ToString(), $"wrong value for Duration2, expected {timeSpanTests.Duration2}, got {dserResult.Duration2}");
+            Assert.Equal(timeSpanTests.Duration3.Ticks.ToString(), dserResult.Duration3.Ticks.ToString(), $"wrong value for Duration3, expected {timeSpanTests.Duration3}, got {dserResult.Duration3}");
+            Assert.Equal(timeSpanTests.Duration4.Ticks.ToString(), dserResult.Duration4.Ticks.ToString(), $"wrong value for Duration4, expected {timeSpanTests.Duration4}, got {dserResult.Duration4}");
+            Assert.Equal(timeSpanTests.Duration5.Ticks.ToString(), dserResult.Duration5.Ticks.ToString(), $"wrong value for Duration5, expected {timeSpanTests.Duration5}, got {dserResult.Duration5}");
+
+            Debug.WriteLine("Can_serialize_deserialize_timespan() - Finished - test succeeded.");
             Debug.WriteLine("");
         }
 

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -465,6 +465,17 @@ namespace nanoFramework.Json
                                                         memberPropSetMethod.Invoke(rootInstance, new object[] { Convert.ToBoolean(Convert.ToByte(val.Value.ToString())) });
                                                         break;
 
+                                                    case nameof(TimeSpan):
+                                                        if (TimeSpanExtensions.TryConvertFromString(val.Value.ToString(), out TimeSpan value))
+                                                        {
+                                                            memberPropSetMethod.Invoke(rootInstance, new object[] { value });
+                                                            break;
+                                                        }
+                                                        else
+                                                        {
+                                                            return null;
+                                                        }
+
                                                     default:
                                                         memberPropSetMethod.Invoke(rootInstance, new object[] { memberPropertyValue.Value });
                                                         break;

--- a/nanoFramework.Json/JsonValue.cs
+++ b/nanoFramework.Json/JsonValue.cs
@@ -60,9 +60,11 @@ namespace nanoFramework.Json
 
                 var type = Value.GetType();
 
-                if (type == typeof(string) || type == typeof(char))
+                if (type == typeof(string)
+                    || type == typeof(char)
+                    || type == typeof(TimeSpan))
                 {
-                    return "\"" + this.Value.ToString() + "\"";
+                    return "\"" + Value.ToString() + "\"";
                 }
                 else if (type == typeof(DateTime))
                 {

--- a/nanoFramework.Json/TimeExtensions.cs
+++ b/nanoFramework.Json/TimeExtensions.cs
@@ -213,4 +213,62 @@ namespace nanoFramework.Json
             return dateTime != DateTime.MaxValue;
         }
     }
+
+    internal static class TimeSpanExtensions
+    {
+        /// <summary>
+        /// Try converting a string value to a <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <param name="value"><see cref="string"/> to convert.</param>
+        /// <param name="timeSpan"><see cref="TimeSpan"/> converted from <paramref name="value"/>.</param>
+        /// <returns><see langword="true"/> if conversion was successful. <see langword="false"/> otherwise.</returns>
+        internal static bool TryConvertFromString(string value, out TimeSpan timeSpan)
+        {
+            timeSpan = TimeSpan.MinValue;
+
+            // split string value with all possible separators
+            // format is: ddddd.HH:mm:ss.fffffff
+            var timeSpanBits = value.Split(':', '.');
+
+            // sanity check
+            if (timeSpanBits.Length < 3)
+            {
+                return false;
+            }
+
+            int days = 0;
+            int ticks = 0;
+
+            // figure out where the separators are
+            int indexOfFirstDot = value.IndexOf('.');
+            int indexOfFirstColon = value.IndexOf(':');
+            int indexOfSecondDot = indexOfFirstDot > -1 ? value.IndexOf('.', indexOfFirstDot) : -1;
+
+            bool hasDays = indexOfFirstDot > 0 && indexOfFirstDot < indexOfFirstColon;
+            bool hasTicks = hasDays ? indexOfSecondDot > indexOfFirstDot : indexOfSecondDot > -1;
+
+            // start parsing
+            if (hasDays)
+            {
+                int.TryParse(timeSpanBits[0], out days);
+            }
+
+            int processIndex = hasDays ? 1 : 0;
+
+            int.TryParse(timeSpanBits[processIndex++], out int hours);
+            int.TryParse(timeSpanBits[processIndex++], out int minutes);
+            int.TryParse(timeSpanBits[processIndex++], out int seconds);
+
+            if (hasTicks)
+            {
+                int.TryParse(timeSpanBits[processIndex], out ticks);
+            }
+
+            // we should have everything now
+            timeSpan = new TimeSpan(ticks).Add(new TimeSpan(days, hours, minutes, seconds, 0));
+
+            // done here
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
## Description
- Add code to deserialize & serialize TimeSpan type.
- Add unit test.

## Motivation and Context
- Adds support to handle this type.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add or improves Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
