### PR TITLE
Fix deserialization of strings with double quotes

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -1396,6 +1396,71 @@ namespace nanoFramework.Json.Test
             OutputHelper.WriteLine($"Deserialization took {endTimestamp - startTimestamp}ms");
         }
 
+        [TestMethod]
+        public void SerializeCosmosDbObject_01()
+        {
+            // TODO need to fix ToString() from string with " inside
+            Assert.SkipTest("Skipping this test for now");
+
+
+            var valueAsJsonString = @"{""_count"":1,""Databases"":[{""_users"":""users/"",""_ts"":1644173816,""id"":""HomeAutomation"",""_rid"":""MfAzAA=="",""_colls"":""colls/"",""_etag"":""\""000020002-0000-0a00-0000-620019f80000\"""",""_self"":""dbs/MFzAA==/""}],""_rid"":null}";
+
+            CosmosDbDatabaseList dbObject = new CosmosDbDatabaseList();
+            dbObject._count = 1;
+
+            dbObject.Databases = new CosmosDbDatabaseList.Database[1];
+            dbObject.Databases[0] = new CosmosDbDatabaseList.Database
+            {
+                id = "HomeAutomation",
+                _rid = "MfAzAA==",
+                _self = "dbs/MFzAA==/",
+                _etag = "\"000020002-0000-0a00-0000-620019f80000\"",
+                _colls = "colls/",
+                _users = "users/",
+                _ts = 1644173816
+            };
+
+            var serializedObject = JsonConvert.SerializeObject(dbObject);
+
+            Assert.Equal(serializedObject, valueAsJsonString, $"Got >>{serializedObject}<<");
+        }
+
+
+        [TestMethod]
+        public void SerializeCosmosDbObject_02()
+        {
+            var valueAsJsonString = @"{
+  ""_rid"": """",
+  ""Databases"": [
+    {
+            ""id"": ""HomeAutomation"",
+      ""_rid"": ""MfAzAA=="",
+      ""_self"": ""dbs/MFzAA==/"",
+      ""_etag"": ""\""000020002-0000-0a00-0000-620019f80000\"""",
+      ""_colls"": ""colls/"",
+      ""_users"": ""users/"",
+      ""_ts"": 1644173816
+    }
+  ],
+  ""_count"": 1
+}";
+
+            var result = (CosmosDbDatabaseList)JsonConvert.DeserializeObject(valueAsJsonString, typeof(CosmosDbDatabaseList));
+
+            Assert.Equal(result._rid, "", "result._rid has wrong value");
+            Assert.Equal(result._count, 1, "result._count has wrong value");
+
+            Assert.Equal(result.Databases.Length, 1, "Databases.Length count is wrong");
+
+            Assert.Equal(result.Databases[0].id, "HomeAutomation", $"Database.id is wrong, got {result.Databases[0].id}");
+            Assert.Equal(result.Databases[0]._rid, "MfAzAA==", $"Database._rid is wrong, got {result.Databases[0]._rid}");
+            Assert.Equal(result.Databases[0]._self, "dbs/MFzAA==/", $"Database._self is wrong, got {result.Databases[0]._self}");
+            Assert.Equal(result.Databases[0]._etag, "\"000020002-0000-0a00-0000-620019f80000\"", $"Database._etag is wrong, got {result.Databases[0]._etag}");
+            Assert.Equal(result.Databases[0]._colls, "colls/", $"Database._colls is wrong, got {result.Databases[0]._colls}");
+            Assert.Equal(result.Databases[0]._users, "users/", $"Database._colls is wrong, got {result.Databases[0]._users}");
+            Assert.Equal(result.Databases[0]._ts, 1644173816, $"Database._ts is wrong, got {result.Databases[0]._ts}");
+        }
+
         private static string testInvocationReceiveMessage = @"{
         ""type"":1,
         ""target"":""ReceiveAdvancedMessage"",
@@ -1701,6 +1766,24 @@ namespace nanoFramework.Json.Test
         public string invocationId { get; set; }
         public string target { get; set; }
         public ArrayList arguments { get; set; }
+    }
+
+    public class CosmosDbDatabaseList
+    {
+        public string _rid { get; set; }
+        public Database[] Databases { get; set; }
+        public int _count { get; set; }
+
+        public class Database
+        {
+            public string id { get; set; }
+            public string _rid { get; set; }
+            public string _self { get; set; }
+            public string _etag { get; set; }
+            public string _colls { get; set; }
+            public string _users { get; set; }
+            public int _ts { get; set; }
+        }
     }
 
     #endregion

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -1357,6 +1357,10 @@ namespace nanoFramework.Json
                             unicodeEncoded = true;
                             break;
 
+                        case '"':
+                            ch = '"';
+                            break;
+
                         default:
                             throw new DeserializationException();
                     }


### PR DESCRIPTION
## Description
- Parser was missing code to deal with " char.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
