### PR TITLE
Fix escape strings during serialization

### DIFF
--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -461,6 +461,24 @@ namespace nanoFramework.Json.Test
             OutputHelper.WriteLine("");
         }
 
+        public class ThingWithString
+        {
+            public string Value { get; set; }
+        }
+
+        [TestMethod]
+        public void Can_serialize_and_deserialize_escaped_string()
+        {
+            var thing = new ThingWithString
+            {
+                Value = "Some string with \" that needs escaping"
+            };
+
+            var serialized = JsonConvert.SerializeObject(thing);
+            var deserialized = (ThingWithString)JsonConvert.DeserializeObject(serialized, typeof(ThingWithString));
+            Assert.Equal(thing.Value, deserialized.Value);
+        }
+
         [TestMethod]
         public void Can_serialize_and_deserialize_complex_object()
         {

--- a/nanoFramework.Json/JsonSerializer.cs
+++ b/nanoFramework.Json/JsonSerializer.cs
@@ -45,10 +45,11 @@ namespace nanoFramework.json
                     return (bool)o ? "true" : "false";
 
                 case "TimeSpan":
-                case "String":
                 case "Char":
                 case "Guid":
                     return "\"" + o.ToString() + "\"";
+                case "String":
+                    return "\"" + SerializeString((string)o) + "\"";
 
                 case "Single":
                     if (float.IsNaN((float)o))


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Strings with quotation marks in them weren't being escaped during serialization

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test to validate round-tripping object with string property that needs escaping

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
