### PR TITLE
Serializer will now ignore: indexer properties, and properties with their name listed in a JsonIgnore above the declaring class.

### DIFF
--- a/nanoFramework.Json/JsonIgnoreAttribute.cs
+++ b/nanoFramework.Json/JsonIgnoreAttribute.cs
@@ -32,9 +32,10 @@ namespace nanoFramework.Json
         /// <summary>
         /// Hides properties from the json serializer
         /// </summary>
-        /// <param name="getterNamesToIgnore"></param>
+        /// <param name="getterNamesToIgnore">a comma separated list of property names to ignore in json</param>
         public JsonIgnoreAttribute(string getterNamesToIgnore)
         {
+            //split by commas, then load array
             PropertyNames = getterNamesToIgnore.Split(',');
             for(int i = 0; i < PropertyNames.Length; i++)
             {

--- a/nanoFramework.Json/JsonIgnoreAttribute.cs
+++ b/nanoFramework.Json/JsonIgnoreAttribute.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+
+namespace nanoFramework.Json
+{
+
+
+
+
+    /// <summary>
+    /// Hides properties from the json serializer
+    /// </summary>
+    [System.AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+    public sealed class JsonIgnoreAttribute : Attribute
+    {
+        // See the attribute guidelines at 
+        //  http://go.microsoft.com/fwlink/?LinkId=85236
+
+        /// <summary>
+        /// Hides properties from the json serializer
+        /// </summary>
+        public JsonIgnoreAttribute() {
+
+            PropertyNames = new string[0];
+        }
+        /// <summary>
+        /// array of property names for json serializer to ignore
+        /// </summary>
+        public string[] PropertyNames { get; set; }
+
+        /// <summary>
+        /// Hides properties from the json serializer
+        /// </summary>
+        /// <param name="getterNamesToIgnore"></param>
+        public JsonIgnoreAttribute(string getterNamesToIgnore)
+        {
+            PropertyNames = getterNamesToIgnore.Split(',');
+            for(int i = 0; i < PropertyNames.Length; i++)
+            {
+                PropertyNames[i] = PropertyNames[i].Trim();
+            }
+        }
+    }
+
+    //implementation to place above individual properties
+    ///// <summary>
+    ///// Hides a property from the json serializer
+    ///// </summary>
+    //[System.AttributeUsage(AttributeTargets.Property | AttributeTargets.Method,
+    //    Inherited = false, AllowMultiple = true)]
+    //public sealed class JsonIgnoreAttribute : Attribute
+    //{
+    //    // See the attribute guidelines at 
+    //    //  http://go.microsoft.com/fwlink/?LinkId=85236
+
+    //    /// <summary>
+    //    /// Hides a property from the json serializer
+    //    /// </summary>
+    //    public JsonIgnoreAttribute() { }
+    //}
+
+}

--- a/nanoFramework.Json/JsonSerializer.cs
+++ b/nanoFramework.Json/JsonSerializer.cs
@@ -137,20 +137,22 @@ namespace nanoFramework.Json
             if (ShouldIgnorePropertyFromClassAttribute(method))
                 return false;
 
-                // per property [JsonIgnore()] attribute - not working due to method.GetCustomAttributes returning empty
-                //var attributes = method.GetCustomAttributes(false);
-                //foreach (var attributeInfo in attributes)
-                //{
-                //    if(typeof(JsonIgnoreAttribute).IsInstanceOfType(attributeInfo))
-                //    {
-                //        return false;
-                //    }
-                //}
+            // per property [JsonIgnore()] attribute - not working due to method.GetCustomAttributes returning empty
+            //var attributes = method.GetCustomAttributes(false);
+            //foreach (var attributeInfo in attributes)
+            //{
+            //    if(typeof(JsonIgnoreAttribute).IsInstanceOfType(attributeInfo))
+            //    {
+            //        return false;
+            //    }
+            //}
 
-                return true;
+            return true;
         }
 
-        //split out method to check for ignore attribute
+        /// <summary>
+        /// split out method to check for ignore attribute
+        /// </summary>
         private static bool ShouldIgnorePropertyFromClassAttribute(MethodInfo method)
         {
             string[] gettersToIgnore = null;
@@ -167,7 +169,7 @@ namespace nanoFramework.Json
             if (gettersToIgnore == null) return false;
             foreach (string propertyName in gettersToIgnore)
             {
-                if(propertyName.Equals(method.Name.Substring(4)))
+                if (propertyName.Equals(method.Name.Substring(4)))
                     return true;
             }
             return false;

--- a/nanoFramework.Json/nanoFramework.Json.nfproj
+++ b/nanoFramework.Json/nanoFramework.Json.nfproj
@@ -52,6 +52,7 @@
     <Compile Include="Converters\UIntConverter.cs" />
     <Compile Include="Converters\ULongConverter.cs" />
     <Compile Include="Converters\UShortConverter.cs" />
+    <Compile Include="JsonIgnoreAttribute.cs" />
     <Compile Include="JsonSerializer.cs" />
     <Compile Include="Resolvers\IMemberResolver.cs" />
     <Compile Include="Resolvers\MemberResolver.cs" />


### PR DESCRIPTION

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Added JsonIgnoreAttribute class, which takes a single string parameter for it's constructor and stores an array of strings. The constructor parameter is expected to be separated by commas, but will tolerate spaces.
- Changed class serialization to check for JsonIgnoreAttribute, and skip properties that match the names listed in the attribute parameter.
- added to the logic for the serialization of classes, so that indexer properties will be passed over without attempting to serialize, and without throwing an error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Increases flexibility for JSON-serializable objects. Before this change, it would have caused an error to serialize an object that defined an indexer property (this[index] operator overload). Also it doesn't appear there was any way to mark a class member NOT to be serialized.
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Regarding discussion in this discord thread: https://discord.com/channels/478725473862549535/1075368316941631488

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I created a NFApp project where I declare a test class with a few properties and an indexer.
- I used the new attribute on the class. I initialized an instance of the class, and then serialized it.
- The serialized output successfully corresponded to the properties not listed in the attribute.
- I deserialized the string back into an object without incident.
I am very new to github, so I am attaching my test project as a zip. I hope to learn the proper procedures for the future. I apologize for any inconvenience.

## Screenshots<!-- (IF APPROPRIATE): -->
[JsonIgnoreTestProject.zip](https://github.com/nanoframework/nanoFramework.Json/files/10761485/JsonIgnoreTestProject.zip)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
