### PR TITLE
Skipping static properties during serialization #1379

### DIFF
--- a/nanoFramework.Json.Test.Shared/JsonTestStaticProperty.cs
+++ b/nanoFramework.Json.Test.Shared/JsonTestStaticProperty.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Text;
+
+namespace nanoFramework.Json.Test.Shared
+{
+    internal class JsonTestStaticProperty
+    {
+        public static JsonTestStaticProperty StaticProperty = new() { InstanceProperty = "StaticValue" };
+
+        public string InstanceProperty { get; set;  } = "DefaultValue";
+    }
+}

--- a/nanoFramework.Json.Test.Shared/nanoFramework.Json.Test.Shared.projitems
+++ b/nanoFramework.Json.Test.Shared/nanoFramework.Json.Test.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)JsonTestClassComplex.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonTestCompany.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonTestEmployee.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)JsonTestStaticProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonTestTown.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Person.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TwinPayload.cs" />

--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -27,6 +27,25 @@ namespace nanoFramework.Json.Test
         }
 
         [TestMethod]
+        public void Can_serialize_and_deserialize_object_with_self_referencing_static_field()
+        {
+            OutputHelper.WriteLine("Can_serialize_and_deserialize_object_with_self_referencing_static_field() - Starting test...");
+
+            var serialized = JsonConvert.SerializeObject(JsonTestStaticProperty.StaticProperty);
+            var deserialized = (JsonTestStaticProperty) JsonConvert.DeserializeObject(serialized, typeof(JsonTestStaticProperty));
+
+            Assert.AreEqual(
+                JsonTestStaticProperty.StaticProperty.InstanceProperty,
+                deserialized.InstanceProperty,
+                $"Validation: JsonTestStaticProperty.StaticProperty.InstanceProperty: {JsonTestStaticProperty.StaticProperty.InstanceProperty}");
+
+            Assert.DoesNotContains(
+                "StaticProperty",
+                serialized,
+                $"Validation: JsonTestStaticProperty.StaticProperty.InstanceProperty: {JsonTestStaticProperty.StaticProperty.InstanceProperty}");
+        }
+
+        [TestMethod]
         public void Can_serialize_and_deserialize_arrays_of_class_objects()
         {
             OutputHelper.WriteLine("Can_serialize_and_deserialize_arrays_of_class_objects() - Starting test...");

--- a/nanoFramework.Json/JsonSerializer.cs
+++ b/nanoFramework.Json/JsonSerializer.cs
@@ -110,6 +110,12 @@ namespace nanoFramework.Json
                 return false;
             }
 
+            // Ignore static methods
+            if (method.IsStatic)
+            {
+                return false;
+            }
+
             // Ignore delegates and MethodInfos
             if ((method.ReturnType == typeof(Delegate)) ||
                 (method.ReturnType == typeof(MulticastDelegate)) ||


### PR DESCRIPTION
## Description

- Skipping static properties while serializing classes

## Motivation and Context

- Fixes nanoFramework/Home#1379

## How Has This Been Tested?

- Just unit test in this project

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [X] I have added new tests to cover my changes.
