### PR TITLE
Rename Settings to JsonSettings

### DIFF
--- a/nanoFramework.Json.Benchmark/Base/BaseIterationBenchmark.cs
+++ b/nanoFramework.Json.Benchmark/Base/BaseIterationBenchmark.cs
@@ -13,7 +13,7 @@ namespace nanoFramework.Json.Benchmark.Base
 
         public void RunInIteration(Action methodToRun)
         {
-            for (int i = 0; i < IterationCount; i++)
+            for (var i = 0; i < IterationCount; i++)
             {
                 methodToRun();
             }

--- a/nanoFramework.Json.Benchmark/Program.cs
+++ b/nanoFramework.Json.Benchmark/Program.cs
@@ -3,8 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
 using nanoFramework.Benchmark;
-using System.Diagnostics;
 using System.Threading;
 
 namespace nanoFramework.Json.Benchmark
@@ -13,8 +13,9 @@ namespace nanoFramework.Json.Benchmark
     {
         public static void Main()
         {
-            Debug.WriteLine("Hello from nanoFramework JSON benchmark!");
-            BenchmarkRunner.Run(typeof(IAssemblyHandler).Assembly);
+            Console.WriteLine("Hello from nanoFramework JSON benchmark!");
+            //BenchmarkRunner.Run(typeof(IAssemblyHandler).Assembly);
+            BenchmarkRunner.RunClass(typeof(TypeBenchmarks));
             Thread.Sleep(Timeout.Infinite);
         }
     }

--- a/nanoFramework.Json.Benchmark/Program.cs
+++ b/nanoFramework.Json.Benchmark/Program.cs
@@ -14,8 +14,7 @@ namespace nanoFramework.Json.Benchmark
         public static void Main()
         {
             Console.WriteLine("Hello from nanoFramework JSON benchmark!");
-            //BenchmarkRunner.Run(typeof(IAssemblyHandler).Assembly);
-            BenchmarkRunner.RunClass(typeof(TypeBenchmarks));
+            BenchmarkRunner.Run(typeof(IAssemblyHandler).Assembly);
             Thread.Sleep(Timeout.Infinite);
         }
     }

--- a/nanoFramework.Json.Benchmark/TypeBenchmarks.cs
+++ b/nanoFramework.Json.Benchmark/TypeBenchmarks.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+using nanoFramework.Benchmark;
+using nanoFramework.Benchmark.Attributes;
+using nanoFramework.Json.Benchmark.Base;
+
+namespace nanoFramework.Json.Benchmark
+{
+    [IterationCount(100)]
+    public class TypeBenchmarks: BaseIterationBenchmark
+    {
+        protected override int IterationCount => 200;
+        
+        private readonly ArrayList _list = new();
+        private const string ArrayListFullName = "System.Collections.ArrayList";
+        private static readonly Type ArrayListType = typeof(ArrayList);
+
+        [Benchmark]
+        public void Benchmark_FullName_Comparison()
+        {
+            RunInIteration(() =>
+            {
+                if (!ArrayListFullName.Equals(_list.GetType().FullName))
+                {
+                    throw new Exception();
+                }
+            });
+        }
+
+        [Benchmark]
+        public void Benchmark_Type_Comparison()
+        {
+            RunInIteration(() =>
+            {
+                if (_list.GetType() != typeof(ArrayList))
+                {
+                    throw new Exception();
+                }
+            });
+        }
+
+        [Benchmark]
+        public void Benchmark_Type_Comparison_Static()
+        {
+            RunInIteration(() =>
+            {
+                if (_list.GetType() != ArrayListType)
+                {
+                    throw new Exception();
+                }
+            });
+        }
+    }
+}

--- a/nanoFramework.Json.Benchmark/nanoFramework.Json.Benchmark.nfproj
+++ b/nanoFramework.Json.Benchmark/nanoFramework.Json.Benchmark.nfproj
@@ -29,6 +29,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DeserializationBenchmarks\ReferenceTypesDeserializationBenchmark.cs" />
     <Compile Include="SerializationBenchmarks\ValueTypesSerializationBenchmark.cs" />
+    <Compile Include="TypeBenchmarks.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/nanoFramework.Json.Test/Configuration/JsonSettingsTests.cs
+++ b/nanoFramework.Json.Test/Configuration/JsonSettingsTests.cs
@@ -1,0 +1,26 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.Json.Configuration;
+using nanoFramework.TestFramework;
+
+namespace nanoFramework.Json.Test.Configuration
+{
+    [TestClass]
+    public class JsonSettingsTests
+    {
+        [TestMethod]
+        public void CaseSensitive_Should_BeTrueByDefault()
+        {
+            Assert.AreEqual(JsonSettings.CaseSensitive, true);
+        }
+
+        [TestMethod]
+        public void ThrowExceptionWhenPropertyNotFound_Should_BeFalseByDefault()
+        {
+            Assert.AreEqual(JsonSettings.ThrowExceptionWhenPropertyNotFound, false);
+        }
+    }
+}

--- a/nanoFramework.Json.Test/Configuration/JsonSettingsTests.cs
+++ b/nanoFramework.Json.Test/Configuration/JsonSettingsTests.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using nanoFramework.Json.Configuration;
 using nanoFramework.TestFramework;
 
 namespace nanoFramework.Json.Test.Configuration
@@ -12,15 +11,15 @@ namespace nanoFramework.Json.Test.Configuration
     public class JsonSettingsTests
     {
         [TestMethod]
-        public void CaseSensitive_Should_BeTrueByDefault()
+        public void PropertyNameCaseInsensitive_Should_Be_False_By_Default()
         {
-            Assert.AreEqual(JsonSettings.CaseSensitive, true);
+            Assert.IsFalse(JsonSerializerOptions.PropertyNameCaseInsensitive);
         }
 
         [TestMethod]
-        public void ThrowExceptionWhenPropertyNotFound_Should_BeFalseByDefault()
+        public void ThrowExceptionWhenPropertyNotFound_Should_Be_False_By_Default()
         {
-            Assert.AreEqual(JsonSettings.ThrowExceptionWhenPropertyNotFound, false);
+            Assert.IsFalse(JsonSerializerOptions.PropertyNameCaseInsensitive);
         }
     }
 }

--- a/nanoFramework.Json.Test/Configuration/SettingsTests.cs
+++ b/nanoFramework.Json.Test/Configuration/SettingsTests.cs
@@ -1,9 +1,6 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// See LICENSE file in the project root for full license information.
-//
-
-using nanoFramework.Json.Configuration;
+﻿using nanoFramework.Json.Configuration;
+using nanoFramework.Json.Resolvers;
+using nanoFramework.Json.Test.Mocks;
 using nanoFramework.TestFramework;
 
 namespace nanoFramework.Json.Test.Configuration
@@ -11,16 +8,58 @@ namespace nanoFramework.Json.Test.Configuration
     [TestClass]
     public class SettingsTests
     {
-        [TestMethod]
-        public void CaseSensitive_Should_BeTrueByDefault()
+        private static bool _caseSensitive;
+        private static IMemberResolver _resolver;
+        private static bool _throwExceptionWhenPropertyNotFound;
+
+        [Cleanup]
+        public void Cleanup()
         {
-            Assert.AreEqual(Settings.CaseSensitive, true);
+            // Restore default settings
+            JsonSettings.CaseSensitive = _caseSensitive;
+            JsonSettings.Resolver = _resolver;
+            JsonSettings.ThrowExceptionWhenPropertyNotFound = _throwExceptionWhenPropertyNotFound;
+        }
+
+        [Setup]
+        public void Setup()
+        {
+            // Capture default settings
+            _caseSensitive = JsonSettings.CaseSensitive;
+            _resolver = JsonSettings.Resolver;
+            _throwExceptionWhenPropertyNotFound = JsonSettings.ThrowExceptionWhenPropertyNotFound;
+        }
+        
+        [TestMethod]
+        public void CaseSensitive_Should_Delegate_To_JsonSettings()
+        {
+#pragma warning disable CS0618
+            Settings.CaseSensitive = !JsonSettings.CaseSensitive;
+
+            Assert.AreEqual(Settings.CaseSensitive, JsonSettings.CaseSensitive);
+#pragma warning restore CS0618
         }
 
         [TestMethod]
-        public void ThrowExceptionWhenPropertyNotFound_Should_BeFalseByDefault()
+        public void Resolver_Should_Delegate_To_JsonSettings()
         {
-            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, false);
+            var resolver = new MockMemberResolver();
+
+#pragma warning disable CS0618
+            Settings.Resolver = resolver;
+
+            Assert.AreEqual(resolver, JsonSettings.Resolver);
+#pragma warning restore CS0618
+        }
+
+        [TestMethod]
+        public void ThrowExceptionWhenPropertyNotFound_Should_Delegate_To_JsonSettings()
+        {
+#pragma warning disable CS0618
+            Settings.ThrowExceptionWhenPropertyNotFound = !JsonSettings.ThrowExceptionWhenPropertyNotFound;
+
+            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, JsonSettings.ThrowExceptionWhenPropertyNotFound);
+#pragma warning restore CS0618
         }
     }
 }

--- a/nanoFramework.Json.Test/Configuration/SettingsTests.cs
+++ b/nanoFramework.Json.Test/Configuration/SettingsTests.cs
@@ -16,27 +16,27 @@ namespace nanoFramework.Json.Test.Configuration
         public void Cleanup()
         {
             // Restore default settings
-            JsonSerializerOptions.PropertyNameCaseInsensitive = _caseSensitive;
-            JsonSerializerOptions.Resolver = _resolver;
-            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = _throwExceptionWhenPropertyNotFound;
+            JsonSerializerOptions.Default.PropertyNameCaseInsensitive = _caseSensitive;
+            JsonSerializerOptions.Default.Resolver = _resolver;
+            JsonSerializerOptions.Default.ThrowExceptionWhenPropertyNotFound = _throwExceptionWhenPropertyNotFound;
         }
 
         [Setup]
         public void Setup()
         {
             // Capture default settings
-            _caseSensitive = JsonSerializerOptions.PropertyNameCaseInsensitive;
-            _resolver = JsonSerializerOptions.Resolver;
-            _throwExceptionWhenPropertyNotFound = JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound;
+            _caseSensitive = JsonSerializerOptions.Default.PropertyNameCaseInsensitive;
+            _resolver = JsonSerializerOptions.Default.Resolver;
+            _throwExceptionWhenPropertyNotFound = JsonSerializerOptions.Default.ThrowExceptionWhenPropertyNotFound;
         }
         
         [TestMethod]
         public void CaseSensitive_Should_Delegate_To_JsonSettings()
         {
 #pragma warning disable CS0618
-            Settings.CaseSensitive = !JsonSerializerOptions.PropertyNameCaseInsensitive;
+            Settings.CaseSensitive = !Settings.CaseSensitive;
 
-            Assert.AreEqual(Settings.CaseSensitive, !JsonSerializerOptions.PropertyNameCaseInsensitive);
+            Assert.AreEqual(Settings.CaseSensitive, !JsonSerializerOptions.Default.PropertyNameCaseInsensitive);
 #pragma warning restore CS0618
         }
 
@@ -48,7 +48,7 @@ namespace nanoFramework.Json.Test.Configuration
 #pragma warning disable CS0618
             Settings.Resolver = resolver;
 
-            Assert.AreEqual(resolver, JsonSerializerOptions.Resolver);
+            Assert.AreEqual(resolver, JsonSerializerOptions.Default.Resolver);
 #pragma warning restore CS0618
         }
 
@@ -56,9 +56,9 @@ namespace nanoFramework.Json.Test.Configuration
         public void ThrowExceptionWhenPropertyNotFound_Should_Delegate_To_JsonSettings()
         {
 #pragma warning disable CS0618
-            Settings.ThrowExceptionWhenPropertyNotFound = !JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound;
+            Settings.ThrowExceptionWhenPropertyNotFound = !Settings.ThrowExceptionWhenPropertyNotFound;
 
-            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound);
+            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, JsonSerializerOptions.Default.ThrowExceptionWhenPropertyNotFound);
 #pragma warning restore CS0618
         }
     }

--- a/nanoFramework.Json.Test/Configuration/SettingsTests.cs
+++ b/nanoFramework.Json.Test/Configuration/SettingsTests.cs
@@ -16,27 +16,27 @@ namespace nanoFramework.Json.Test.Configuration
         public void Cleanup()
         {
             // Restore default settings
-            JsonSettings.CaseSensitive = _caseSensitive;
-            JsonSettings.Resolver = _resolver;
-            JsonSettings.ThrowExceptionWhenPropertyNotFound = _throwExceptionWhenPropertyNotFound;
+            JsonSerializerOptions.PropertyNameCaseInsensitive = _caseSensitive;
+            JsonSerializerOptions.Resolver = _resolver;
+            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = _throwExceptionWhenPropertyNotFound;
         }
 
         [Setup]
         public void Setup()
         {
             // Capture default settings
-            _caseSensitive = JsonSettings.CaseSensitive;
-            _resolver = JsonSettings.Resolver;
-            _throwExceptionWhenPropertyNotFound = JsonSettings.ThrowExceptionWhenPropertyNotFound;
+            _caseSensitive = JsonSerializerOptions.PropertyNameCaseInsensitive;
+            _resolver = JsonSerializerOptions.Resolver;
+            _throwExceptionWhenPropertyNotFound = JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound;
         }
         
         [TestMethod]
         public void CaseSensitive_Should_Delegate_To_JsonSettings()
         {
 #pragma warning disable CS0618
-            Settings.CaseSensitive = !JsonSettings.CaseSensitive;
+            Settings.CaseSensitive = !JsonSerializerOptions.PropertyNameCaseInsensitive;
 
-            Assert.AreEqual(Settings.CaseSensitive, JsonSettings.CaseSensitive);
+            Assert.AreEqual(Settings.CaseSensitive, !JsonSerializerOptions.PropertyNameCaseInsensitive);
 #pragma warning restore CS0618
         }
 
@@ -48,7 +48,7 @@ namespace nanoFramework.Json.Test.Configuration
 #pragma warning disable CS0618
             Settings.Resolver = resolver;
 
-            Assert.AreEqual(resolver, JsonSettings.Resolver);
+            Assert.AreEqual(resolver, JsonSerializerOptions.Resolver);
 #pragma warning restore CS0618
         }
 
@@ -56,9 +56,9 @@ namespace nanoFramework.Json.Test.Configuration
         public void ThrowExceptionWhenPropertyNotFound_Should_Delegate_To_JsonSettings()
         {
 #pragma warning disable CS0618
-            Settings.ThrowExceptionWhenPropertyNotFound = !JsonSettings.ThrowExceptionWhenPropertyNotFound;
+            Settings.ThrowExceptionWhenPropertyNotFound = !JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound;
 
-            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, JsonSettings.ThrowExceptionWhenPropertyNotFound);
+            Assert.AreEqual(Settings.ThrowExceptionWhenPropertyNotFound, JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound);
 #pragma warning restore CS0618
         }
     }

--- a/nanoFramework.Json.Test/JsonSettingsTests.cs
+++ b/nanoFramework.Json.Test/JsonSettingsTests.cs
@@ -5,7 +5,7 @@
 
 using nanoFramework.TestFramework;
 
-namespace nanoFramework.Json.Test.Configuration
+namespace nanoFramework.Json.Test
 {
     [TestClass]
     public class JsonSettingsTests
@@ -13,13 +13,13 @@ namespace nanoFramework.Json.Test.Configuration
         [TestMethod]
         public void PropertyNameCaseInsensitive_Should_Be_False_By_Default()
         {
-            Assert.IsFalse(JsonSerializerOptions.PropertyNameCaseInsensitive);
+            Assert.IsFalse(JsonSerializerOptions.Default.PropertyNameCaseInsensitive);
         }
 
         [TestMethod]
         public void ThrowExceptionWhenPropertyNotFound_Should_Be_False_By_Default()
         {
-            Assert.IsFalse(JsonSerializerOptions.PropertyNameCaseInsensitive);
+            Assert.IsFalse(JsonSerializerOptions.Default.PropertyNameCaseInsensitive);
         }
     }
 }

--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -930,7 +930,7 @@ namespace nanoFramework.Json.Test
             Assert.AreEqual(dserResult.target, "ReceiveAdvancedMessage", "target value is not correct");
 
             Assert.AreEqual((int)dserResult.arguments[2], 3, "arguments[2] value is not correct");
-            Assert.IsType(typeof(ArrayList), dserResult.arguments, "arguments type it's wrong after deserialization");
+            Assert.IsInstanceOfType(dserResult.arguments, typeof(ArrayList), "arguments type it's wrong after deserialization");
             Assert.AreEqual(dserResult.arguments.Count, 3, $"number of arguments is different than expected: {dserResult.arguments.Count}");
 
             Hashtable arg0 = (Hashtable)dserResult.arguments[0];
@@ -971,7 +971,7 @@ namespace nanoFramework.Json.Test
             Assert.AreEqual(dserResult.target, "ReceiveAdvancedMessage", "target value is not correct");
 
             Assert.AreEqual((int)dserResult.arguments[2], 3, "arguments[2] value is not correct");
-            Assert.IsType(typeof(ArrayList), dserResult.arguments, "arguments type it's wrong after deserialization");
+            Assert.IsInstanceOfType(dserResult.arguments, typeof(ArrayList), "arguments type it's wrong after deserialization");
             Assert.AreEqual(dserResult.arguments.Count, 3, $"number of arguments is different than expected: {dserResult.arguments.Count}");
 
             OutputHelper.WriteLine("Serializing dserResult.arguments[0]");
@@ -1022,7 +1022,7 @@ namespace nanoFramework.Json.Test
             Assert.AreEqual(dserResult.type, 1, "type value is not correct");
             Assert.AreEqual(dserResult.target, "ReceiveMessage", "target value is not correct");
 
-            Assert.IsType(typeof(ArrayList), dserResult.arguments, "arguments type it's wrong after deserialization");
+            Assert.IsInstanceOfType(dserResult.arguments, typeof(ArrayList), "arguments type it's wrong after deserialization");
             Assert.AreEqual(dserResult.arguments.Count, 2, $"number of arguments is different than expected: {dserResult.arguments.Count}");
 
             OutputHelper.WriteLine($"SerializingdserResult.arguments[0]:{dserResult.arguments[0]}");
@@ -1081,7 +1081,7 @@ namespace nanoFramework.Json.Test
 
             Hashtable desired = (Hashtable)hash["desired"];
 
-            Assert.IsType(typeof(string), desired["Authorization"], "Authorization is not a string and it should be.");
+            Assert.IsInstanceOfType(desired["Authorization"], typeof(string), "Authorization is not a string and it should be.");
 
             Assert.AreEqual("sp=r&st=2021-06-12T09:11:53Z&se=2021-06-14T17:11:53Z&spr=https&sv=2020-02-10&sr=c&sig=rn125LiO55RSCoEs4IEaCgg%2BuXKETdEZQPygxVjCHiY%3D", (string)desired["Authorization"], "Authorization string doesn't match original value.");
 
@@ -1100,7 +1100,7 @@ namespace nanoFramework.Json.Test
 
             Hashtable hash = (Hashtable)JsonConvert.DeserializeObject(correctValue, typeof(Hashtable));
 
-            Assert.IsType(typeof(string), hash["Authorization"], "Authorization is not a string and it should be.");
+            Assert.IsInstanceOfType(hash["Authorization"], typeof(string), "Authorization is not a string and it should be.");
             Assert.AreEqual("sp=r&st=2021-06-12T09:11:53Z&se=2021-06-14T17:11:53Z&spr=https&sv=2020-02-10&sr=c&sig=rn125LiO55RSCoEs4IEaCgg%2BuXKETdEZQPygxVjCHiY%3D", (string)hash["Authorization"], "Authorization string doesn't match original value.");
 
             ArrayList files = (ArrayList)hash["Files"];

--- a/nanoFramework.Json.Test/JsonUnitTests.cs
+++ b/nanoFramework.Json.Test/JsonUnitTests.cs
@@ -1087,7 +1087,7 @@ namespace nanoFramework.Json.Test
 
             ArrayList files = (ArrayList)desired["Files"];
 
-            Assert.IsType(typeof(string), files[0]);
+            Assert.IsInstanceOfType(files[0], typeof(string));
             Assert.AreEqual("Iot.Device.Bmxx80.pe", (string)files[0]);
         }
 
@@ -1105,7 +1105,7 @@ namespace nanoFramework.Json.Test
 
             ArrayList files = (ArrayList)hash["Files"];
 
-            Assert.IsType(typeof(string), files[0]);
+            Assert.IsInstanceOfType(files[0], typeof(string));
             Assert.AreEqual("Iot.Device.Bmxx80.pe", (string)files[0]);
         }
 

--- a/nanoFramework.Json.Test/Mocks/MockMemberResolver.cs
+++ b/nanoFramework.Json.Test/Mocks/MockMemberResolver.cs
@@ -5,7 +5,7 @@ namespace nanoFramework.Json.Test.Mocks
 {
     internal class MockMemberResolver: IMemberResolver
     {
-        public MemberSet Get(string memberName, Type objectType)
+        public MemberSet Get(string memberName, Type objectType, JsonSerializerOptions options)
         {
             return new MemberSet(true);
         }

--- a/nanoFramework.Json.Test/Mocks/MockMemberResolver.cs
+++ b/nanoFramework.Json.Test/Mocks/MockMemberResolver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using nanoFramework.Json.Resolvers;
+
+namespace nanoFramework.Json.Test.Mocks
+{
+    internal class MockMemberResolver: IMemberResolver
+    {
+        public MemberSet Get(string memberName, Type objectType)
+        {
+            return new MemberSet(true);
+        }
+    }
+}

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
@@ -5,7 +5,6 @@
 
 using nanoFramework.Json.Resolvers;
 using nanoFramework.TestFramework;
-using System;
 
 namespace nanoFramework.Json.Test.Resolvers
 {
@@ -15,57 +14,33 @@ namespace nanoFramework.Json.Test.Resolvers
         private sealed class TestClass
         {
             public int NoGetProperty { private get; set; } = 1;
-            public int NoSetProperty { get; } = 1;
-        }
-
-        [Setup]
-        public void MemberResolverCaseInsensitiveExceptionTests_Setup()
-        {
-            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = true;
-            JsonSerializerOptions.PropertyNameCaseInsensitive = true;
-        }
-
-        [Cleanup]
-        public void MemberResolverCaseInsensitiveExceptionTests_Cleanup()
-        {
-            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = false;
-            JsonSerializerOptions.PropertyNameCaseInsensitive = false;
+            public int NoSetProperty => 1;
         }
 
         [TestMethod]
         public void MemberResolverCaseInsensitiveExceptionTests_Get_ShouldSkipPropertyWithoutGet()
         {
-            var resolver = new MemberResolver();
-
-            try
+            var options = new JsonSerializerOptions
             {
-                resolver.Get(nameof(TestClass.NoGetProperty), typeof(TestClass));
-            }
-            catch (DeserializationException)
-            {
-                // Intended. Method should throw this type of exception when no set method.
-                return;
-            }
+                PropertyNameCaseInsensitive = true,
+                ThrowExceptionWhenPropertyNotFound = true,
+            };
 
-            throw new InvalidOperationException($"Should throw {nameof(DeserializationException)}.");
+            var sut = new MemberResolver();
+            Assert.ThrowsException(typeof(DeserializationException), () => sut.Get(nameof(TestClass.NoGetProperty), typeof(TestClass), options));
         }
 
         [TestMethod]
         public void MemberResolverCaseInsensitiveExceptionTests_Get_ShouldSkipPropertyWithoutSet()
         {
-            var resolver = new MemberResolver();
-
-            try
+            var options = new JsonSerializerOptions
             {
-                resolver.Get(nameof(TestClass.NoSetProperty), typeof(TestClass));
-            }
-            catch (DeserializationException)
-            {
-                // Intended. Method should throw this type of exception when no set method.
-                return;
-            }
+                PropertyNameCaseInsensitive = true,
+                ThrowExceptionWhenPropertyNotFound = true,
+            };
 
-            throw new InvalidOperationException($"Should throw {nameof(DeserializationException)}.");
+            var sut = new MemberResolver();
+            Assert.ThrowsException(typeof(DeserializationException), () => sut.Get(nameof(TestClass.NoSetProperty), typeof(TestClass), options));
         }
     }
 }

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using nanoFramework.Json.Configuration;
 using nanoFramework.Json.Resolvers;
 using nanoFramework.TestFramework;
 using System;
@@ -22,15 +21,15 @@ namespace nanoFramework.Json.Test.Resolvers
         [Setup]
         public void MemberResolverCaseInsensitiveExceptionTests_Setup()
         {
-            JsonSettings.ThrowExceptionWhenPropertyNotFound = true;
-            JsonSettings.CaseSensitive = false;
+            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = true;
+            JsonSerializerOptions.PropertyNameCaseInsensitive = true;
         }
 
         [Cleanup]
         public void MemberResolverCaseInsensitiveExceptionTests_Cleanup()
         {
-            JsonSettings.ThrowExceptionWhenPropertyNotFound = false;
-            JsonSettings.CaseSensitive = true;
+            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = false;
+            JsonSerializerOptions.PropertyNameCaseInsensitive = false;
         }
 
         [TestMethod]

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveExceptionTests.cs
@@ -22,15 +22,15 @@ namespace nanoFramework.Json.Test.Resolvers
         [Setup]
         public void MemberResolverCaseInsensitiveExceptionTests_Setup()
         {
-            Settings.ThrowExceptionWhenPropertyNotFound = true;
-            Settings.CaseSensitive = false;
+            JsonSettings.ThrowExceptionWhenPropertyNotFound = true;
+            JsonSettings.CaseSensitive = false;
         }
 
         [Cleanup]
         public void MemberResolverCaseInsensitiveExceptionTests_Cleanup()
         {
-            Settings.ThrowExceptionWhenPropertyNotFound = false;
-            Settings.CaseSensitive = true;
+            JsonSettings.ThrowExceptionWhenPropertyNotFound = false;
+            JsonSettings.CaseSensitive = true;
         }
 
         [TestMethod]

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
@@ -4,7 +4,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using nanoFramework.Json.Configuration;
 using nanoFramework.Json.Resolvers;
 using nanoFramework.TestFramework;
 
@@ -16,19 +15,19 @@ namespace nanoFramework.Json.Test.Resolvers
         private sealed class TestClass
         {
             public int TestField = 1;
-            public int TestProperty { get; set; } = 1;
+            public int TestProperty { get; init; } = 1;
         }
 
         [Setup]
         public void MemberResolverCaseInsensitiveTests_Setup()
         {
-            JsonSettings.CaseSensitive = false;
+            JsonSerializerOptions.PropertyNameCaseInsensitive = true;
         }
 
         [Cleanup]
         public void MemberResolverCaseInsensitive_Cleanup()
         {
-            JsonSettings.CaseSensitive = true;
+            JsonSerializerOptions.PropertyNameCaseInsensitive = false;
         }
 
         [TestMethod]
@@ -36,7 +35,7 @@ namespace nanoFramework.Json.Test.Resolvers
         {
             var resolver = new MemberResolver();
             var classInstance = new TestClass();
-            var valueToSet = 6;
+            const int valueToSet = 6;
 
             var member = resolver.Get(nameof(TestClass.TestProperty).ToLower(), typeof(TestClass));
             member.SetValue(classInstance, valueToSet);
@@ -51,7 +50,7 @@ namespace nanoFramework.Json.Test.Resolvers
         {
             var resolver = new MemberResolver();
             var classInstance = new TestClass();
-            var valueToSet = 5;
+            const int valueToSet = 5;
 
             var member = resolver.Get(nameof(TestClass.TestField).ToLower(), typeof(TestClass));
             member.SetValue(classInstance, valueToSet);

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
@@ -22,13 +22,13 @@ namespace nanoFramework.Json.Test.Resolvers
         [Setup]
         public void MemberResolverCaseInsensitiveTests_Setup()
         {
-            Settings.CaseSensitive = false;
+            JsonSettings.CaseSensitive = false;
         }
 
         [Cleanup]
         public void MemberResolverCaseInsensitive_Cleanup()
         {
-            Settings.CaseSensitive = true;
+            JsonSettings.CaseSensitive = true;
         }
 
         [TestMethod]

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseInsensitiveTests.cs
@@ -18,26 +18,19 @@ namespace nanoFramework.Json.Test.Resolvers
             public int TestProperty { get; init; } = 1;
         }
 
-        [Setup]
-        public void MemberResolverCaseInsensitiveTests_Setup()
-        {
-            JsonSerializerOptions.PropertyNameCaseInsensitive = true;
-        }
-
-        [Cleanup]
-        public void MemberResolverCaseInsensitive_Cleanup()
-        {
-            JsonSerializerOptions.PropertyNameCaseInsensitive = false;
-        }
-
         [TestMethod]
         public void MemberResolverCaseInsensitive_Get_ShouldReturnCaseInsensitivePropertyWhenSet()
         {
-            var resolver = new MemberResolver();
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var sut = new MemberResolver();
             var classInstance = new TestClass();
             const int valueToSet = 6;
 
-            var member = resolver.Get(nameof(TestClass.TestProperty).ToLower(), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.TestProperty).ToLower(), typeof(TestClass), options);
             member.SetValue(classInstance, valueToSet);
 
             Assert.AreEqual(classInstance.TestProperty, valueToSet);
@@ -48,11 +41,16 @@ namespace nanoFramework.Json.Test.Resolvers
         [TestMethod]
         public void MemberResolverCaseInsensitive_Get_ShouldReturnCaseInsensitiveFieldWhenSet()
         {
-            var resolver = new MemberResolver();
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var sut = new MemberResolver();
             var classInstance = new TestClass();
             const int valueToSet = 5;
 
-            var member = resolver.Get(nameof(TestClass.TestField).ToLower(), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.TestField).ToLower(), typeof(TestClass), options);
             member.SetValue(classInstance, valueToSet);
 
             Assert.AreEqual(classInstance.TestField, valueToSet);
@@ -62,11 +60,16 @@ namespace nanoFramework.Json.Test.Resolvers
         [TestMethod]
         public void MemberResolverCaseInsensitive_Get_ShouldSkipWhenNotFoundCaseInsensitiveProperty()
         {
-            var resolver = new MemberResolver();
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
 
-            var member = resolver.Get("NotExistingProperty", typeof(TestClass));
+            var sut = new MemberResolver();
 
-            Assert.AreEqual(member.Skip, true);
+            var member = sut.Get("NotExistingProperty", typeof(TestClass), options);
+
+            Assert.IsTrue(member.Skip);
         }
     }
 }

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
@@ -22,13 +22,13 @@ namespace nanoFramework.Json.Test.Resolvers
         [Setup]
         public void MemberResolverCaseSensitiveExceptionTests_Setup()
         {
-            Settings.ThrowExceptionWhenPropertyNotFound = true;
+            JsonSettings.ThrowExceptionWhenPropertyNotFound = true;
         }
 
         [Cleanup]
         public void MemberResolverCaseSensitiveExceptionTests_Cleanup()
         {
-            Settings.ThrowExceptionWhenPropertyNotFound = false;
+            JsonSettings.ThrowExceptionWhenPropertyNotFound = false;
         }
 
         [TestMethod]

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using nanoFramework.Json.Configuration;
 using nanoFramework.Json.Resolvers;
 using nanoFramework.TestFramework;
 using System;
@@ -22,13 +21,13 @@ namespace nanoFramework.Json.Test.Resolvers
         [Setup]
         public void MemberResolverCaseSensitiveExceptionTests_Setup()
         {
-            JsonSettings.ThrowExceptionWhenPropertyNotFound = true;
+            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = true;
         }
 
         [Cleanup]
         public void MemberResolverCaseSensitiveExceptionTests_Cleanup()
         {
-            JsonSettings.ThrowExceptionWhenPropertyNotFound = false;
+            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = false;
         }
 
         [TestMethod]

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveExceptionTests.cs
@@ -5,7 +5,6 @@
 
 using nanoFramework.Json.Resolvers;
 using nanoFramework.TestFramework;
-using System;
 
 namespace nanoFramework.Json.Test.Resolvers
 {
@@ -15,55 +14,31 @@ namespace nanoFramework.Json.Test.Resolvers
         private sealed class TestClass
         {
             public int NoGetProperty { private get; set; } = 1;
-            public int NoSetProperty { get; } = 1;
-        }
-
-        [Setup]
-        public void MemberResolverCaseSensitiveExceptionTests_Setup()
-        {
-            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = true;
-        }
-
-        [Cleanup]
-        public void MemberResolverCaseSensitiveExceptionTests_Cleanup()
-        {
-            JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = false;
+            public int NoSetProperty => 1;
         }
 
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldThrowPropertyWithoutGetWhenSet()
         {
-            var resolver = new MemberResolver();
-
-            try
+            var options = new JsonSerializerOptions
             {
-                resolver.Get(nameof(TestClass.NoGetProperty), typeof(TestClass));
-            }
-            catch (DeserializationException)
-            {
-                // Intended. Method should throw this type of exception when no set method.
-                return;
-            }
+                ThrowExceptionWhenPropertyNotFound = true
+            };
 
-            throw new InvalidOperationException($"Should throw {nameof(DeserializationException)}.");
+            var sut = new MemberResolver();
+            Assert.ThrowsException(typeof(DeserializationException), () => sut.Get(nameof(TestClass.NoGetProperty), typeof(TestClass), options));
         }
 
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldThrowPropertyWithoutSetWhenSet()
         {
-            var resolver = new MemberResolver();
-
-            try
+            var options = new JsonSerializerOptions
             {
-                resolver.Get(nameof(TestClass.NoSetProperty), typeof(TestClass));
-            }
-            catch (DeserializationException)
-            {
-                // Intended. Method should throw this type of exception when no set method.
-                return;
-            }
+                ThrowExceptionWhenPropertyNotFound = true
+            };
 
-            throw new InvalidOperationException($"Should throw {nameof(DeserializationException)}.");
+            var sut = new MemberResolver();
+            Assert.ThrowsException(typeof(DeserializationException), () => sut.Get(nameof(TestClass.NoSetProperty), typeof(TestClass), options));
         }
     }
 }

--- a/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveTests.cs
+++ b/nanoFramework.Json.Test/Resolvers/MemberResolverCaseSensitiveTests.cs
@@ -15,19 +15,19 @@ namespace nanoFramework.Json.Test.Resolvers
         private sealed class TestClass
         {
             public int TestField = 1;
-            public int TestProperty { get; set; } = 1;
+            public int TestProperty { get; init; } = 1;
             public int NoGetProperty { private get; set; } = 1;
-            public int NoSetProperty { get; } = 1;
+            public int NoSetProperty => 1;
         }
 
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldResolveField()
         {
-            var resolver = new MemberResolver();
+            var sut = new MemberResolver();
             var classInstance = new TestClass();
-            var valueToSet = 5;
+            const int valueToSet = 5;
 
-            var member = resolver.Get(nameof(TestClass.TestField), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.TestField), typeof(TestClass), new JsonSerializerOptions());
             member.SetValue(classInstance, valueToSet);
 
             Assert.AreEqual(classInstance.TestField, valueToSet);
@@ -37,11 +37,11 @@ namespace nanoFramework.Json.Test.Resolvers
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldResolveProperty()
         {
-            var resolver = new MemberResolver();
+            var sut = new MemberResolver();
             var classInstance = new TestClass();
-            var valueToSet = 6;
+            const int valueToSet = 6;
 
-            var member = resolver.Get(nameof(TestClass.TestProperty), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.TestProperty), typeof(TestClass), new JsonSerializerOptions());
             member.SetValue(classInstance, valueToSet);
 
             Assert.AreEqual(classInstance.TestProperty, valueToSet);
@@ -51,9 +51,9 @@ namespace nanoFramework.Json.Test.Resolvers
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldSkipPropertyWithoutGet()
         {
-            var resolver = new MemberResolver();
+            var sut = new MemberResolver();
 
-            var member = resolver.Get(nameof(TestClass.NoGetProperty), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.NoGetProperty), typeof(TestClass), new JsonSerializerOptions());
 
             Assert.IsTrue(member.Skip);
         }
@@ -61,9 +61,9 @@ namespace nanoFramework.Json.Test.Resolvers
         [TestMethod]
         public void MemberResolverCaseSensitive_Get_ShouldSkipPropertyWithoutSet()
         {
-            var resolver = new MemberResolver();
+            var sut = new MemberResolver();
 
-            var member = resolver.Get(nameof(TestClass.NoSetProperty), typeof(TestClass));
+            var member = sut.Get(nameof(TestClass.NoSetProperty), typeof(TestClass), new JsonSerializerOptions());
 
             Assert.IsTrue(member.Skip);
         }

--- a/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
+++ b/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
@@ -33,6 +33,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="Configuration\ConvertersMappingTests.cs" />
+    <Compile Include="Configuration\JsonSettingsTests.cs" />
     <Compile Include="Configuration\SettingsTests.cs" />
     <Compile Include="Converters\DateTimeConverterTests.cs" />
     <Compile Include="Converters\SByteConverterTests.cs" />
@@ -52,6 +53,7 @@
     <Compile Include="JsonDeserializationArraysTests.cs" />
     <Compile Include="JsonThreadSafeTests.cs" />
     <Compile Include="JsonUnitTests.cs" />
+    <Compile Include="Mocks\MockMemberResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resolvers\MemberResolverCaseInsensitiveExceptionTests.cs" />
     <Compile Include="Resolvers\MemberResolverCaseInsensitiveTests.cs" />

--- a/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
+++ b/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
@@ -33,7 +33,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="Configuration\ConvertersMappingTests.cs" />
-    <Compile Include="Configuration\JsonSettingsTests.cs" />
+    <Compile Include="JsonSettingsTests.cs" />
     <Compile Include="Configuration\SettingsTests.cs" />
     <Compile Include="Converters\DateTimeConverterTests.cs" />
     <Compile Include="Converters\SByteConverterTests.cs" />

--- a/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
+++ b/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
@@ -78,11 +78,9 @@
     </Reference>
     <Reference Include="nanoFramework.TestFramework, Version=2.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.TestFramework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams">
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>

--- a/nanoFramework.Json/Configuration/ConvertersMapping.cs
+++ b/nanoFramework.Json/Configuration/ConvertersMapping.cs
@@ -7,6 +7,7 @@ using nanoFramework.Json.Converters;
 using System;
 using System.Collections;
 
+// TODO: Look into moving this into JsonSerializationOptions
 namespace nanoFramework.Json.Configuration
 {
     /// <summary>

--- a/nanoFramework.Json/Configuration/JsonSettings.cs
+++ b/nanoFramework.Json/Configuration/JsonSettings.cs
@@ -4,42 +4,28 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
 using nanoFramework.Json.Resolvers;
 
 namespace nanoFramework.Json.Configuration
 {
     /// <summary>
-    /// Common settings for JSON converter. This class delegates to <see cref="JsonSettings"/>
+    /// Common settings for JSON converter.
     /// </summary>
-    [Obsolete("Use JsonSettings instead")]
-    public static class Settings
+    public static class JsonSettings
     {
         /// <summary>
         /// Gets or sets resolver which is used to find properties in target object when deserializing JSON.
         /// </summary>
-        public static IMemberResolver Resolver
-        {
-            get => JsonSettings.Resolver;
-            set => JsonSettings.Resolver = value;
-        }
+        public static IMemberResolver Resolver { get; set; } = new MemberResolver();
 
         /// <summary>
         /// Gets or sets a value indicating whether property resolving should be case sensitive.
         /// </summary>
-        public static bool CaseSensitive 
-        { 
-            get => JsonSettings.CaseSensitive;
-            set => JsonSettings.CaseSensitive = value;
-        }
+        public static bool CaseSensitive { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether deserialization should throw exception when no property found.
         /// </summary>
-        public static bool ThrowExceptionWhenPropertyNotFound
-        {
-            get => JsonSettings.ThrowExceptionWhenPropertyNotFound; 
-            set => JsonSettings.ThrowExceptionWhenPropertyNotFound = value;
-        }
+        public static bool ThrowExceptionWhenPropertyNotFound { get; set; } = false;
     }
 }

--- a/nanoFramework.Json/Configuration/Settings.cs
+++ b/nanoFramework.Json/Configuration/Settings.cs
@@ -10,9 +10,9 @@ using nanoFramework.Json.Resolvers;
 namespace nanoFramework.Json.Configuration
 {
     /// <summary>
-    /// Common settings for JSON converter. This class delegates to <see cref="JsonSettings"/>
+    /// Common settings for JSON converter. This class delegates to <see cref="JsonSerializerOptions"/>
     /// </summary>
-    [Obsolete("Use JsonSettings instead")]
+    [Obsolete("Use JsonSerializerOptions instead")]
     public static class Settings
     {
         /// <summary>
@@ -20,17 +20,17 @@ namespace nanoFramework.Json.Configuration
         /// </summary>
         public static IMemberResolver Resolver
         {
-            get => JsonSettings.Resolver;
-            set => JsonSettings.Resolver = value;
+            get => JsonSerializerOptions.Resolver;
+            set => JsonSerializerOptions.Resolver = value;
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether property resolving should be case sensitive.
+        /// Gets or sets a value indicating whether property resolving should be case-sensitive.
         /// </summary>
         public static bool CaseSensitive 
         { 
-            get => JsonSettings.CaseSensitive;
-            set => JsonSettings.CaseSensitive = value;
+            get => !JsonSerializerOptions.PropertyNameCaseInsensitive;
+            set => JsonSerializerOptions.PropertyNameCaseInsensitive = !value;
         }
 
         /// <summary>
@@ -38,8 +38,8 @@ namespace nanoFramework.Json.Configuration
         /// </summary>
         public static bool ThrowExceptionWhenPropertyNotFound
         {
-            get => JsonSettings.ThrowExceptionWhenPropertyNotFound; 
-            set => JsonSettings.ThrowExceptionWhenPropertyNotFound = value;
+            get => JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound; 
+            set => JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = value;
         }
     }
 }

--- a/nanoFramework.Json/Configuration/Settings.cs
+++ b/nanoFramework.Json/Configuration/Settings.cs
@@ -20,8 +20,8 @@ namespace nanoFramework.Json.Configuration
         /// </summary>
         public static IMemberResolver Resolver
         {
-            get => JsonSerializerOptions.Resolver;
-            set => JsonSerializerOptions.Resolver = value;
+            get => JsonSerializerOptions.Default.Resolver;
+            set => JsonSerializerOptions.Default.Resolver = value;
         }
 
         /// <summary>
@@ -29,8 +29,8 @@ namespace nanoFramework.Json.Configuration
         /// </summary>
         public static bool CaseSensitive 
         { 
-            get => !JsonSerializerOptions.PropertyNameCaseInsensitive;
-            set => JsonSerializerOptions.PropertyNameCaseInsensitive = !value;
+            get => !JsonSerializerOptions.Default.PropertyNameCaseInsensitive;
+            set => JsonSerializerOptions.Default.PropertyNameCaseInsensitive = !value;
         }
 
         /// <summary>
@@ -38,8 +38,8 @@ namespace nanoFramework.Json.Configuration
         /// </summary>
         public static bool ThrowExceptionWhenPropertyNotFound
         {
-            get => JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound; 
-            set => JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound = value;
+            get => JsonSerializerOptions.Default.ThrowExceptionWhenPropertyNotFound; 
+            set => JsonSerializerOptions.Default.ThrowExceptionWhenPropertyNotFound = value;
         }
     }
 }

--- a/nanoFramework.Json/Converters/DictionaryEntryConverter.cs
+++ b/nanoFramework.Json/Converters/DictionaryEntryConverter.cs
@@ -17,11 +17,10 @@ namespace nanoFramework.Json.Converters
         {
             Hashtable hashtable = new();
 
-            DictionaryEntry dic = (DictionaryEntry)value;
-            DictionaryEntry entry = dic;
+            var entry = (DictionaryEntry)value;
             hashtable.Add(entry.Key, entry.Value);
 
-            return JsonSerializer.SerializeIDictionary(hashtable);
+            return JsonSerializer.SerializeDictionary(hashtable);
         }
 
         /// <summary>

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -36,12 +36,12 @@ namespace nanoFramework.Json
         /// <summary>
         /// Convert an object to a JSON string.
         /// </summary>
-        /// <param name="oSource">The value to convert. Supported types are: Boolean, String, Byte, (U)Int16, (U)Int32, Float, Double, Decimal, Array, IDictionary, IEnumerable, Guid, Datetime, DictionaryEntry, Object and null.</param>
+        /// <param name="value">The value to convert. Supported types are: Boolean, String, Byte, (U)Int16, (U)Int32, Float, Double, Decimal, Array, IDictionary, IEnumerable, Guid, Datetime, DictionaryEntry, Object and null.</param>
         /// <returns>The JSON object as a string or null when the value type is not supported.</returns>
         /// <remarks>For objects, only public properties with getters are converted.</remarks>
-        public static string SerializeObject(object oSource)
+        public static string SerializeObject(object value)
         {
-            return JsonSerializer.SerializeObject(oSource);
+            return JsonSerializer.SerializeObject(value);
         }
 
         /// <summary>

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -254,7 +254,7 @@ namespace nanoFramework.Json
                     }
 
                     // Call current resolver to get info how to deal with data
-                    var memberResolver = Settings.Resolver.Get(memberPropertyName, rootType);
+                    var memberResolver = JsonSettings.Resolver.Get(memberPropertyName, rootType);
                     if (memberResolver.Skip)
                     {
                         continue;

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -658,51 +658,18 @@ namespace nanoFramework.Json
             return result;
         }
 
-        private static Hashtable PopulateHashtable(JsonObject rootObject)
+        private static Hashtable PopulateHashtable(JsonObject jsonObject)
         {
             var result = new Hashtable();
 
-            foreach (JsonProperty member in rootObject.Members)
+            foreach (JsonProperty jsonProperty in jsonObject.Members)
             {
-                if (member is null)
+                if (jsonProperty is null)
                 {
-                    throw new NotSupportedException();
+                    throw new DeserializationException();
                 }
 
-                switch (member.Value)
-                {
-                    // Process the member based on JObject, JValue, or JArray
-                    case JsonObject jsonObject:
-                    {
-                        result.Add(member.Name, PopulateHashtable(jsonObject));
-                        break;
-                    }
-                    case JsonValue jsonValue:
-                    {
-                        result.Add(member.Name, jsonValue.Value);
-                        break;
-                    }
-                    case JsonArray jsonArray:
-                    {
-                        var valueArrayList = new ArrayList();
-                        var valueItems = jsonArray.Items;
-
-                        foreach (var valueItem in valueItems)
-                        {
-                            if (valueItem is JsonValue jsonValue)
-                            {
-                                valueArrayList.Add(jsonValue.Value);
-                            }
-                            else if (valueItem is JsonObject jsonObject)
-                            {
-                                valueArrayList.Add(PopulateHashtable(jsonObject));
-                            }
-                        }
-
-                        result.Add(member.Name, valueArrayList);
-                        break;
-                    }
-                }
+                result.Add(jsonProperty.Name, PopulateObject(jsonProperty.Value));
             }
 
             return result;

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -254,7 +254,7 @@ namespace nanoFramework.Json
                     }
 
                     // Call current resolver to get info how to deal with data
-                    var memberResolver = JsonSettings.Resolver.Get(memberPropertyName, rootType);
+                    var memberResolver = JsonSerializerOptions.Resolver.Get(memberPropertyName, rootType);
                     if (memberResolver.Skip)
                     {
                         continue;

--- a/nanoFramework.Json/JsonConvert.cs
+++ b/nanoFramework.Json/JsonConvert.cs
@@ -243,58 +243,12 @@ namespace nanoFramework.Json
 
             var elementType = type.GetElementType();
 
-            if (elementType is null && type.FullName == "System.Collections.ArrayList")
+            switch (elementType)
             {
-                ArrayList rootArrayList = new();
-
-                // In case we have elements to put there.
-                var result = new Hashtable();
-                foreach (var m in rootObject.Members)
-                {
-                    var memberProperty = (JsonProperty)m;
-
-                    if (m is JsonValue value)
-                    {
-                        rootArrayList.Add(value.Value);
-                    }
-                    else if (m is JsonArray jsonArray)
-                    {
-                        rootArrayList.Add(PopulateArrayList(jsonArray));
-                    }
-                    else if (m is JsonToken)
-                    {
-                        result.Add(memberProperty.Name, PopulateObject(memberProperty.Value));
-                    }
-                    else
-                    {
-                        throw new DeserializationException();
-                    }
-                }
-
-                if (result.Count > 0)
-                {
-                    rootArrayList.Add(result);
-                }
-
-                return PopulateArrayList(rootObject);
-                return rootArrayList;
-            }
-
-            if (elementType is null && type.FullName == "System.Collections.Hashtable")
-            {
-                var result = new Hashtable();
-
-                foreach (var member in rootObject.Members)
-                {
-                    if (member is not JsonProperty jsonProperty)
-                    {
-                        throw new DeserializationException();
-                    }
-
-                    result.Add(jsonProperty.Name, PopulateObject(jsonProperty.Value));
-                }
-
-                return PopulateHashtable(rootObject);
+                case null when type.FullName == "System.Collections.ArrayList":
+                    return PopulateArrayList(rootObject);
+                case null when type.FullName == "System.Collections.Hashtable":
+                    return PopulateHashtable(rootObject);
             }
 
             var converter = ConvertersMapping.GetConverter(type);
@@ -590,7 +544,7 @@ namespace nanoFramework.Json
 
         private static object Deserialize(Stream sourceStream)
         {
-            // Read the sourcestream into jsonBytes[]
+            // Read the source stream into jsonBytes[]
             var jsonBytes = new byte[sourceStream.Length];
             sourceStream.Read(jsonBytes, 0, (int)sourceStream.Length);
             var jsonPos = 0;
@@ -673,6 +627,7 @@ namespace nanoFramework.Json
             return Deserialize(ref jsonPos, ref jsonBytes);
         }
 
+        // ReSharper disable once RedundantAssignment
         private static JsonObject ParseObject(ref int jsonPos, ref byte[] jsonBytes, ref LexToken token)
         {
             var result = new JsonObject();
@@ -857,10 +812,6 @@ namespace nanoFramework.Json
         }
 
         private static LexToken GetNextToken(ref int jsonPos, ref byte[] jsonBytes)
-        {
-            return GetNextTokenInternal(ref jsonPos, ref jsonBytes);
-        }
-        private static LexToken GetNextTokenInternal(ref int jsonPos, ref byte[] jsonBytes)
         {
             StringBuilder sb = null;
 

--- a/nanoFramework.Json/JsonSerializer.cs
+++ b/nanoFramework.Json/JsonSerializer.cs
@@ -17,7 +17,7 @@ namespace nanoFramework.Json
     /// </summary>
     public class JsonSerializer
     {
-        JsonSerializer()
+        private JsonSerializer()
         {
         }
 
@@ -39,7 +39,7 @@ namespace nanoFramework.Json
 
             if (topObject
                 && !type.IsArray
-                && type.BaseType.FullName == "System.ValueType")
+                && type.BaseType?.FullName == "System.ValueType")
             {
                 return $"[{SerializeObject(o, false)}]";
             }

--- a/nanoFramework.Json/JsonSerializerDefaults.cs
+++ b/nanoFramework.Json/JsonSerializerDefaults.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text;
+
+namespace nanoFramework.Json
+{
+    /// <summary>Specifies scenario-based default serialization options that can be used to construct a <see cref="T:nanoFramework.Json.JsonSerializerOptions" /> instance.</summary>
+    public enum JsonSerializerDefaults
+    {
+        /// <summary>
+        ///   <para>General-purpose option values. These are the same settings that are applied if a <see cref="T:nanoFramework.Json.JsonSerializerDefaults" /> member isn't specified.</para>
+        ///   <para>For information about the default property values that are applied, see JsonSerializerOptions properties.</para>
+        /// </summary>
+        General,
+        /// <summary>
+        ///   <para>Option values appropriate to Web-based scenarios.</para>
+        ///   <para>This member implies that:</para>
+        ///   <para>- Property names are treated as case-insensitive.</para>
+        /// </summary>
+        Web,
+    }
+}

--- a/nanoFramework.Json/JsonSerializerOptions.cs
+++ b/nanoFramework.Json/JsonSerializerOptions.cs
@@ -4,31 +4,74 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#nullable enable
 using nanoFramework.Json.Resolvers;
+using System;
 
 namespace nanoFramework.Json
 {
-    // TODO: Remove static
     /// <summary>
-    /// Common settings for JSON converter.
+    /// Provides options to be used with <see cref="JsonSerializer"/>.
     /// </summary>
-    public static class JsonSerializerOptions
+    public sealed class JsonSerializerOptions
     {
+        private static JsonSerializerOptions? _defaultOptions;
+
+        /// <summary>
+        /// Constructs a new <see cref="JsonSerializerOptions"/> instance.
+        /// </summary>
+        public JsonSerializerOptions()
+        {
+            PropertyNameCaseInsensitive = false;
+            Resolver = new MemberResolver();
+            ThrowExceptionWhenPropertyNotFound = false;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="JsonSerializerOptions"/> instance with a predefined set of options determined by the specified <see cref="JsonSerializerDefaults"/>.
+        /// </summary>
+        /// <param name="defaults"> The <see cref="JsonSerializerDefaults"/> to reason about.</param>
+        public JsonSerializerOptions(JsonSerializerDefaults defaults) : this()
+        {
+            if (defaults == JsonSerializerDefaults.Web)
+            {
+                PropertyNameCaseInsensitive = true;
+            }
+            else if (defaults != JsonSerializerDefaults.General)
+            {
+                throw new ArgumentOutOfRangeException(nameof(defaults));
+            }
+        }
+
+        // TODO: Find all test uses and use specific instances rather than changing defaults
+        /// <summary>
+        /// Gets a singleton instance of <see cref="JsonSerializerOptions" /> that uses the default configuration.
+        /// </summary>
+        public static JsonSerializerOptions Default
+        {
+            get
+            {
+                _defaultOptions ??= new JsonSerializerOptions();
+                return _defaultOptions;
+            }
+        }
+
         /// <summary>
         /// Gets or sets resolver which is used to find properties in target object when deserializing JSON.
         /// </summary>
-        public static IMemberResolver Resolver { get; set; } = new MemberResolver();
+        public IMemberResolver Resolver { get; set; }
 
         /// <summary>
         /// Determines whether a property's name uses a case-insensitive comparison during deserialization.
         /// The default value is false.
         /// </summary>
         /// <remarks>There is a performance cost associated when the value is true.</remarks>
-        public static bool PropertyNameCaseInsensitive { get; set; } = false;
+        public bool PropertyNameCaseInsensitive { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether deserialization should throw exception when no property found.
+        /// The default value is false.
         /// </summary>
-        public static bool ThrowExceptionWhenPropertyNotFound { get; set; } = false;
+        public bool ThrowExceptionWhenPropertyNotFound { get; set; }
     }
 }

--- a/nanoFramework.Json/JsonSerializerOptions.cs
+++ b/nanoFramework.Json/JsonSerializerOptions.cs
@@ -6,12 +6,13 @@
 
 using nanoFramework.Json.Resolvers;
 
-namespace nanoFramework.Json.Configuration
+namespace nanoFramework.Json
 {
+    // TODO: Remove static
     /// <summary>
     /// Common settings for JSON converter.
     /// </summary>
-    public static class JsonSettings
+    public static class JsonSerializerOptions
     {
         /// <summary>
         /// Gets or sets resolver which is used to find properties in target object when deserializing JSON.
@@ -19,9 +20,11 @@ namespace nanoFramework.Json.Configuration
         public static IMemberResolver Resolver { get; set; } = new MemberResolver();
 
         /// <summary>
-        /// Gets or sets a value indicating whether property resolving should be case sensitive.
+        /// Determines whether a property's name uses a case-insensitive comparison during deserialization.
+        /// The default value is false.
         /// </summary>
-        public static bool CaseSensitive { get; set; } = true;
+        /// <remarks>There is a performance cost associated when the value is true.</remarks>
+        public static bool PropertyNameCaseInsensitive { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether deserialization should throw exception when no property found.

--- a/nanoFramework.Json/Resolvers/IMemberResolver.cs
+++ b/nanoFramework.Json/Resolvers/IMemberResolver.cs
@@ -18,7 +18,8 @@ namespace nanoFramework.Json.Resolvers
         /// </summary>
         /// <param name="memberName">Key from JSON property. Property name we are looking for.</param>
         /// <param name="objectType">Type of object in which <paramref name="memberName"/> should be.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> to be used.</param>
         /// <returns>Data about member which we want to populate based on passed parameters.</returns>
-        MemberSet Get(string memberName, Type objectType);
+        MemberSet Get(string memberName, Type objectType, JsonSerializerOptions options);
     }
 }

--- a/nanoFramework.Json/Resolvers/MemberResolver.cs
+++ b/nanoFramework.Json/Resolvers/MemberResolver.cs
@@ -4,7 +4,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using nanoFramework.Json.Configuration;
 using System;
 using System.Reflection;
 
@@ -39,12 +38,7 @@ namespace nanoFramework.Json.Resolvers
 
         private MemberSet HandleNullPropertyMember(string memberName, Type objectType)
         {
-            if (!JsonSettings.CaseSensitive)
-            {
-                return GetInsensitive(memberName, objectType);
-            }
-
-            return HandlePropertyNotFound();
+            return JsonSerializerOptions.PropertyNameCaseInsensitive ? GetInsensitive(memberName, objectType) : HandlePropertyNotFound();
         }
 
         internal MemberSet GetInsensitive(string memberName, Type objectType)
@@ -74,7 +68,7 @@ namespace nanoFramework.Json.Resolvers
 
         private MemberSet HandlePropertyNotFound()
         {
-            if (JsonSettings.ThrowExceptionWhenPropertyNotFound)
+            if (JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound)
             {
                 throw new DeserializationException();
             }

--- a/nanoFramework.Json/Resolvers/MemberResolver.cs
+++ b/nanoFramework.Json/Resolvers/MemberResolver.cs
@@ -39,7 +39,7 @@ namespace nanoFramework.Json.Resolvers
 
         private MemberSet HandleNullPropertyMember(string memberName, Type objectType)
         {
-            if (!Settings.CaseSensitive)
+            if (!JsonSettings.CaseSensitive)
             {
                 return GetInsensitive(memberName, objectType);
             }
@@ -74,7 +74,7 @@ namespace nanoFramework.Json.Resolvers
 
         private MemberSet HandlePropertyNotFound()
         {
-            if (Settings.ThrowExceptionWhenPropertyNotFound)
+            if (JsonSettings.ThrowExceptionWhenPropertyNotFound)
             {
                 throw new DeserializationException();
             }

--- a/nanoFramework.Json/Resolvers/MemberResolver.cs
+++ b/nanoFramework.Json/Resolvers/MemberResolver.cs
@@ -11,76 +11,36 @@ namespace nanoFramework.Json.Resolvers
 {
     internal sealed class MemberResolver : IMemberResolver
     {
-        public MemberSet Get(string memberName, Type objectType)
+        public MemberSet Get(string memberName, Type objectType, JsonSerializerOptions options)
         {
             var memberFieldInfo = objectType.GetField(memberName);
 
             // Value will be set via field
             if (memberFieldInfo != null)
             {
-                return new MemberSet(new SetValueDelegate((instance, value) => memberFieldInfo.SetValue(instance, value)), memberFieldInfo.FieldType);
+                return new MemberSet((instance, value) => memberFieldInfo.SetValue(instance, value), memberFieldInfo.FieldType);
             }
 
             var memberPropGetMethod = objectType.GetMethod("get_" + memberName);
-            if (memberPropGetMethod == null)
+            if (memberPropGetMethod is null)
             {
-                return HandleNullPropertyMember(memberName, objectType);
+                return HandleNullPropertyMember(memberName, objectType, options);
             }
 
             var memberPropSetMethod = objectType.GetMethod("set_" + memberName);
-            if (memberPropSetMethod == null)
+            if (memberPropSetMethod is null)
             {
-                return HandleNullPropertyMember(memberName, objectType);
+                return HandleNullPropertyMember(memberName, objectType, options);
             }
 
-            return new MemberSet(new SetValueDelegate((instance, value) => memberPropSetMethod.Invoke(instance, new object[] { value })), memberPropGetMethod.ReturnType);
-        }
-
-        private MemberSet HandleNullPropertyMember(string memberName, Type objectType)
-        {
-            return JsonSerializerOptions.PropertyNameCaseInsensitive ? GetInsensitive(memberName, objectType) : HandlePropertyNotFound();
-        }
-
-        internal MemberSet GetInsensitive(string memberName, Type objectType)
-        {
-            var memberFieldInfo = GetFieldInfoCaseInsensitive(objectType, memberName);
-
-            // Value will be set via field
-            if (memberFieldInfo != null)
-            {
-                return new MemberSet(new SetValueDelegate((instance, value) => memberFieldInfo.SetValue(instance, value)), memberFieldInfo.FieldType);
-            }
-
-            var memberPropGetMethod = GetMethodCaseInsensitive(objectType, "get_" + memberName);
-            if (memberPropGetMethod == null)
-            {
-                return HandlePropertyNotFound();
-            }
-
-            var memberPropSetMethod = GetMethodCaseInsensitive(objectType, "set_" + memberName);
-            if (memberPropSetMethod == null)
-            {
-                return HandlePropertyNotFound();
-            }
-
-            return new MemberSet(new SetValueDelegate((instance, value) => memberPropSetMethod.Invoke(instance, new object[] { value })), memberPropGetMethod.ReturnType);
-        }
-
-        private MemberSet HandlePropertyNotFound()
-        {
-            if (JsonSerializerOptions.ThrowExceptionWhenPropertyNotFound)
-            {
-                throw new DeserializationException();
-            }
-
-            return new MemberSet(true);
+            return new MemberSet((instance, value) => memberPropSetMethod.Invoke(instance, new[] { value }), memberPropGetMethod.ReturnType);
         }
 
         private static FieldInfo GetFieldInfoCaseInsensitive(Type objectType, string fieldName)
         {
             foreach (var field in objectType.GetFields())
             {
-                if (field.Name.ToLower() == fieldName.ToLower())
+                if (string.Equals(field.Name.ToLower(), fieldName.ToLower()))
                 {
                     return field;
                 }
@@ -89,17 +49,57 @@ namespace nanoFramework.Json.Resolvers
             return null;
         }
 
+        internal MemberSet GetInsensitive(string memberName, Type objectType, JsonSerializerOptions options)
+        {
+            var memberFieldInfo = GetFieldInfoCaseInsensitive(objectType, memberName);
+
+            // Value will be set via field
+            if (memberFieldInfo is not null)
+            {
+                return new MemberSet((instance, value) => memberFieldInfo.SetValue(instance, value), memberFieldInfo.FieldType);
+            }
+
+            var memberPropGetMethod = GetMethodCaseInsensitive(objectType, "get_" + memberName);
+            if (memberPropGetMethod is null)
+            {
+                return HandlePropertyNotFound(options);
+            }
+
+            var memberPropSetMethod = GetMethodCaseInsensitive(objectType, "set_" + memberName);
+            if (memberPropSetMethod is null)
+            {
+                return HandlePropertyNotFound(options);
+            }
+
+            return new MemberSet((instance, value) => memberPropSetMethod.Invoke(instance, new[] { value }), memberPropGetMethod.ReturnType);
+        }
+
         private static MethodInfo GetMethodCaseInsensitive(Type objectType, string methodName)
         {
             foreach (var method in objectType.GetMethods())
             {
-                if (method.Name.ToLower() == methodName.ToLower())
+                if (string.Equals(method.Name.ToLower(), methodName.ToLower()))
                 {
                     return method;
                 }
             }
 
             return null;
+        }
+
+        private MemberSet HandleNullPropertyMember(string memberName, Type objectType, JsonSerializerOptions options)
+        {
+            return options.PropertyNameCaseInsensitive ? GetInsensitive(memberName, objectType, options) : HandlePropertyNotFound(options);
+        }
+
+        private static MemberSet HandlePropertyNotFound(JsonSerializerOptions options)
+        {
+            if (options.ThrowExceptionWhenPropertyNotFound)
+            {
+                throw new DeserializationException();
+            }
+
+            return new MemberSet(true);
         }
     }
 }

--- a/nanoFramework.Json/TypeUtils.cs
+++ b/nanoFramework.Json/TypeUtils.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+using System;
+using System.Collections;
+
+namespace nanoFramework.Json
+{
+    internal static class TypeUtils
+    {
+        // A very small optimization occurs by caching these types
+        public static readonly Type ArrayListType = typeof(ArrayList);
+        public static readonly Type HashTableType = typeof(Hashtable);
+        public static readonly Type StringType = typeof(string);
+        public static readonly Type ValueTypeType = typeof(ValueType);
+
+        public static bool IsArrayList(Type? type) => ArrayListType == type;
+
+        public static bool IsHashTable(Type? type) => HashTableType == type;
+
+        public static bool IsString(Type? type) => StringType == type;
+
+        public static bool IsValueType(Type? type) => ValueTypeType == type?.BaseType;
+    }
+}

--- a/nanoFramework.Json/nanoFramework.Json.nfproj
+++ b/nanoFramework.Json/nanoFramework.Json.nfproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Compile Include="Configuration\JsonSettings.cs" />
+    <Compile Include="JsonSerializerOptions.cs" />
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Converters\BoolConverter.cs" />
     <Compile Include="Converters\ByteConverter.cs" />

--- a/nanoFramework.Json/nanoFramework.Json.nfproj
+++ b/nanoFramework.Json/nanoFramework.Json.nfproj
@@ -68,6 +68,7 @@
     <Compile Include="JsonValue.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeExtensions.cs" />
+    <Compile Include="TypeUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\key.snk" />

--- a/nanoFramework.Json/nanoFramework.Json.nfproj
+++ b/nanoFramework.Json/nanoFramework.Json.nfproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="JsonSerializerDefaults.cs" />
     <Compile Include="JsonSerializerOptions.cs" />
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Converters\BoolConverter.cs" />

--- a/nanoFramework.Json/nanoFramework.Json.nfproj
+++ b/nanoFramework.Json/nanoFramework.Json.nfproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="Configuration\JsonSettings.cs" />
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Converters\BoolConverter.cs" />
     <Compile Include="Converters\ByteConverter.cs" />


### PR DESCRIPTION
## Description
- Create new `JsonSettings` class that mirrors existing `Settings` class.
- Update `Settings` to delegate properties to `JsonSettings`
- Mark `Settings` as obsolete

## Motivation and Context
This is an opinionated change and entirely optional. My strong belief is that code should be self documenting and the existing `Settings` class, without the namespace context, is ambiguous. 

By renaming to `JsonSettings` the intent is clear and users (like me) that don't read the documentation are more likely to discover the class.

- nanoFramework/Home#1382

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests
- Live device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [X] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project (only if there are changes in source code).
- [X] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
