### PR TITLE
Handle negative time span

### DIFF
--- a/nanoFramework.Json.Test/Converters/TimeSpanConverterTests.cs
+++ b/nanoFramework.Json.Test/Converters/TimeSpanConverterTests.cs
@@ -20,6 +20,11 @@ namespace nanoFramework.Json.Test.Converters
                 "-1.02:03:04.005",
                 "1.02:03:04.0050000",
                 "4.03:02:01.654321",
+                "4.03:02:01.65432",
+                "4.03:02:01.6543",
+                "4.03:02:01.654",
+                "4.03:02:01.65",
+                "4.03:02:01.6",
                 "04:20:19",
                 "07:32",
             };
@@ -29,6 +34,11 @@ namespace nanoFramework.Json.Test.Converters
                 -new TimeSpan(1, 2, 3, 4, 5),
                 new TimeSpan(1, 2, 3, 4, 5),
                 new TimeSpan(4, 3, 2, 1, 654).Add(new TimeSpan(3210)),
+                new TimeSpan(4, 3, 2, 1, 654).Add(new TimeSpan(3200)),
+                new TimeSpan(4, 3, 2, 1, 654).Add(new TimeSpan(3000)),
+                new TimeSpan(4, 3, 2, 1, 654),
+                new TimeSpan(4, 3, 2, 1, 650),
+                new TimeSpan(4, 3, 2, 1, 600),
                 new TimeSpan(4, 20, 19),
                 new TimeSpan(7, 32, 0),
             };

--- a/nanoFramework.Json.Test/Converters/TimeSpanConverterTests.cs
+++ b/nanoFramework.Json.Test/Converters/TimeSpanConverterTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using nanoFramework.Json.Converters;
 using nanoFramework.TestFramework;
 using System;
 
@@ -12,26 +13,67 @@ namespace nanoFramework.Json.Test.Converters
     public class TimeSpanConverterTests
     {
         [TestMethod]
-        [DataRow("10:00:00", 10)]
-        [DataRow("24:00:00", 24)]
-        public void TimeSpanConverter_ToType_ShouldReturnValidData(string value, int expectedValueHours)
+        public void TimeSpanConverter_ToType_Should_Return_Valid_Data()
         {
-            var converter = new Json.Converters.TimeSpanConverter();
-            var convertedValue = (TimeSpan)converter.ToType(value);
+            var values = new[]
+            {
+                "-1.02:03:04.005",
+                "1.02:03:04.0050000",
+                "4.03:02:01.654321",
+                "04:20:19",
+                "07:32",
+            };
 
-            var expectedTimeSpanValue = TimeSpan.FromHours(expectedValueHours);
-            Assert.AreEqual(expectedTimeSpanValue.Ticks, convertedValue.Ticks);
+            var expected = new[]
+            {
+                -new TimeSpan(1, 2, 3, 4, 5),
+                new TimeSpan(1, 2, 3, 4, 5),
+                new TimeSpan(4, 3, 2, 1, 654).Add(new TimeSpan(3210)),
+                new TimeSpan(4, 20, 19),
+                new TimeSpan(7, 32, 0),
+            };
+
+            var sut = new TimeSpanConverter();
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                var actual = (TimeSpan) sut.ToType(values[i]);
+
+                Assert.AreEqual(expected[i], actual);
+            }
         }
 
         [TestMethod]
-        [DataRow(10, "\"10:00:00\"")]
-        [DataRow(24, "\"24:00:00\"")]
-        public void TimeSpanConverter_ToJson_Should_ReturnValidData(int valueHours, string expectedValue)
+        public void TimeSpanConverter_ToJson_Should_Return_Valid_Data()
         {
-            var converter = new Json.Converters.TimeSpanConverter();
-            var convertedValue = converter.ToJson(TimeSpan.FromHours(valueHours));
+            var values = new[]
+            {
+                -new TimeSpan(1, 2, 3, 4, 5),
+                new TimeSpan(1, 2, 3, 4, 5),
+                new TimeSpan(4, 3, 2, 1, 654).Add(new TimeSpan(3210)),
+                new TimeSpan(4, 20, 19),
+                new TimeSpan(7, 32, 0),
+                new TimeSpan(0, 29, 0),
+            };
 
-            Assert.AreEqual(expectedValue, convertedValue);
+            var expected = new[]
+            {
+                "\"-1.02:03:04.0050000\"",
+                "\"1.02:03:04.0050000\"",
+                "\"4.03:02:01.6543210\"",
+                "\"04:20:19\"",
+                "\"07:32:00\"",
+                "\"00:29:00\"",
+            };
+
+            var sut = new TimeSpanConverter();
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                var actual = sut.ToJson(values[i]);
+
+                Assert.AreEqual(expected[i], actual);
+            }
         }
     }
 }

--- a/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
+++ b/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
@@ -59,39 +59,33 @@
     <Compile Include="Resolvers\MemberResolverCaseSensitiveTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.TestFramework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Content Include="packages.lock.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nanoFramework.Json\nanoFramework.Json.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Collections">
+      <HintPath>..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Text">
+      <HintPath>..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.TestFramework">
+      <HintPath>..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.UnitTestLauncher">
+      <HintPath>..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Streams">
+      <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.lock.json" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\nanoFramework.Json.Test.Shared\nanoFramework.Json.Test.Shared.projitems" Label="Shared" />
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/nanoFramework.Json/Converters/TimeSpanConverter.cs
+++ b/nanoFramework.Json/Converters/TimeSpanConverter.cs
@@ -12,10 +12,7 @@ namespace nanoFramework.Json.Converters
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
-        public string ToJson(object value)
-        {
-            return "\"" + value.ToString() + "\"";
-        }
+        public string ToJson(object value) => $"\"{value}\"";
 
         /// <summary>
         /// <inheritdoc/>
@@ -34,32 +31,34 @@ namespace nanoFramework.Json.Converters
         {
             // split string value with all possible separators
             // format is: -ddddd.HH:mm:ss.fffffff
-            var timeSpanBits = value.Split(':', '.');
+            var tokens = value.Split(':', '.');
 
             // sanity check
-            if (timeSpanBits.Length == 0)
+            if (tokens.Length == 0)
             {
                 return TimeSpan.Zero;
             }
 
             // figure out where the separators are
-            int indexOfFirstDot = value.IndexOf('.');
-            int indexOfSecondDot = indexOfFirstDot > -1 ? value.IndexOf('.', indexOfFirstDot + 1) : -1;
-            int indexOfFirstColon = value.IndexOf(':');
-            int indexOfSecondColon = indexOfFirstColon > -1 ? value.IndexOf(':', indexOfFirstColon + 1) : -1;
+            var indexOfFirstDot = value.IndexOf('.');
+            var indexOfSecondDot = indexOfFirstDot > -1 ? value.IndexOf('.', indexOfFirstDot + 1) : -1;
+            var indexOfFirstColon = value.IndexOf(':');
+            var indexOfSecondColon = indexOfFirstColon > -1 ? value.IndexOf(':', indexOfFirstColon + 1) : -1;
 
             // sanity check for separators: all have to be ahead of string start
-            if (SeparatorCheck(timeSpanBits, indexOfFirstDot, indexOfSecondDot, indexOfFirstColon, indexOfSecondColon))
+            if (SeparatorCheck(tokens, indexOfFirstDot, indexOfSecondDot, indexOfFirstColon, indexOfSecondColon))
             {
                 throw new InvalidCastException();
             }
 
+            var isNegative = value.StartsWith("-");
+
             // to have days, it has to have something before the 1st dot, or just have a single component
-            bool hasDays = (indexOfFirstDot > 0 && indexOfFirstDot < indexOfFirstColon) || timeSpanBits.Length == 1;
-            bool hasTicks = hasDays ? indexOfSecondDot > indexOfFirstDot : indexOfFirstDot > -1;
-            bool hasHours = indexOfFirstColon > 0;
-            bool hasMinutes = hasHours && indexOfFirstColon > -1;
-            bool hasSeconds = hasMinutes && indexOfSecondColon > -1;
+            var hasDays = (indexOfFirstDot > 0 && indexOfFirstDot < indexOfFirstColon) || tokens.Length == 1;
+            var hasTicks = hasDays ? indexOfSecondDot > indexOfFirstDot : indexOfFirstDot > -1;
+            var hasHours = indexOfFirstColon > 0;
+            var hasMinutes = hasHours && indexOfFirstColon > -1;
+            var hasSeconds = hasMinutes && indexOfSecondColon > -1;
 
             // sanity check for ticks without other time components
             if (hasTicks && !hasHours)
@@ -68,20 +67,13 @@ namespace nanoFramework.Json.Converters
             }
 
             // let the parsing start!
-            int days = 0;
-            if (hasDays
-                && !int.TryParse(timeSpanBits[0], out days))
-            {
-                throw new InvalidCastException();
-            }
+            var tokenIndex = 0;
 
-            // bump the index if days component is present
-            int processIndex = hasDays ? 1 : 0;
-
-            var hours = ParseValueFromString(hasHours, timeSpanBits, ref processIndex);
-            var minutes = ParseValueFromString(hasMinutes, timeSpanBits, ref processIndex);
-            var seconds = ParseValueFromString(hasSeconds, timeSpanBits, ref processIndex);
-            var ticks = HandleTicks(timeSpanBits, hasTicks, processIndex);
+            var days = ParseToken(hasDays, tokens, ref tokenIndex);
+            var hours = ParseToken(hasHours, tokens, ref tokenIndex);
+            var minutes = ParseToken(hasMinutes, tokens, ref tokenIndex);
+            var seconds = ParseToken(hasSeconds, tokens, ref tokenIndex);
+            var ticks = ParseTicks(hasTicks, tokens, tokenIndex);
 
             // sanity check for valid ranges
             if (IsInvalidTimeSpan(hours, minutes, seconds))
@@ -90,77 +82,86 @@ namespace nanoFramework.Json.Converters
             }
 
             // we should have everything now
-            return new TimeSpan(ticks).Add(new TimeSpan(days, hours, minutes, seconds, 0));
-        }
+            var timeSpan = new TimeSpan(days, hours, minutes, seconds, 0).Add(new TimeSpan(ticks));
 
-        private static int HandleTicks(string[] timeSpanBits, bool hasTicks, int processIndex)
-        {
-            if (!hasTicks || processIndex > timeSpanBits.Length)
-            {
-                return 0;
-            }
-
-            if (!int.TryParse(timeSpanBits[processIndex], out var ticks))
-            {
-                throw new InvalidCastException();
-            }
-
-            // if ticks are under 999, that's milliseconds
-            if (ticks < 1_000)
-            {
-                ticks *= 10_000;
-            }
-
-            return ticks;
-        }
-
-        private static bool SeparatorCheck(string[] timeSpanBits, int indexOfFirstDot, int indexOfSecondDot, int indexOfFirstColon, int indexOfSecondColon)
-        {
-            return timeSpanBits.Length > 1
-                            && indexOfFirstDot <= 0
-                            && indexOfSecondDot <= 0
-                            && indexOfFirstColon <= 0
-                            && indexOfSecondColon <= 0;
-        }
-
-        private static int ParseValueFromString(bool hasValue,string[] timeSpanBits, ref int processIndex)
-        {
-            if (!hasValue)
-            {
-                return 0;
-            }
-
-            if (processIndex > timeSpanBits.Length)
-            {
-                return 0;
-            }
-
-            if (!int.TryParse(timeSpanBits[processIndex++], out var value))
-            {
-                throw new InvalidCastException();
-            }
-
-            return value;
+            return isNegative ? -timeSpan : timeSpan;
         }
 
         private static bool IsInvalidTimeSpan(int hour, int minutes, int seconds)
         {
-            if (hour < 0 || hour > 24)
+            if (hour is < 0 or > 24)
             {
                 return true;
             }
 
-            if (minutes < 0 || minutes >= 60)
+            if (minutes is < 0 or >= 60)
             {
                 return true;
             }
 
-            if (seconds < 0 || seconds >= 60)
+            if (seconds is < 0 or >= 60)
             {
                 return true;
             }
 
             return false;
+        }
+
+        private static int ParseTicks(bool hasTicks, string[] tokens, int tokenIndex)
+        {
+            if (!hasTicks || tokenIndex > tokens.Length)
+            {
+                return 0;
+            }
+
+            var token = tokens[tokenIndex];
+
+            if (token.Length > 7)
+            {
+                token = token.Substring(0, 7);
+            }
+
+            if (!int.TryParse(token, out var value))
+            {
+                throw new InvalidCastException();
+            }
+
+            value = token.Length switch
+            {
+                1 => value * 1_000_000,
+                2 => value * 100_000,
+                3 => value * 10_000,
+                4 => value * 1_000,
+                5 => value * 100,
+                6 => value * 10,
+                _ => value
+            };
+
+            return value >= 0 ? value : value * -1;
+        }
+
+        private static int ParseToken(bool hasValue, string[] tokens, ref int tokenIndex)
+        {
+            if (!hasValue || tokenIndex > tokens.Length)
+            {
+                return 0;
+            }
+
+            if (!int.TryParse(tokens[tokenIndex++], out var value))
+            {
+                throw new InvalidCastException();
+            }
+
+            return value >= 0 ? value : value * -1;
+        }
+
+        private static bool SeparatorCheck(string[] tokens, int indexOfFirstDot, int indexOfSecondDot, int indexOfFirstColon, int indexOfSecondColon)
+        {
+            return tokens.Length > 1
+                   && indexOfFirstDot <= 0
+                   && indexOfSecondDot <= 0
+                   && indexOfFirstColon <= 0
+                   && indexOfSecondColon <= 0;
         }
     }
 }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Fix incorrect negative TimeSpan parsing
- Fix incorrect handling of ticks

## Motivation and Context
The previous logic did not properly handle negative TimeSpan strings or fractional seconds with anything other than 3 or 7 digits

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Unit tests

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [X] I have added new tests to cover my changes.
