### PR TITLE
Two bugs of iCal parsing was fixed

### DIFF
--- a/nanoFramework.Json.Test/DateTimeExtensionsTests.cs
+++ b/nanoFramework.Json.Test/DateTimeExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.TestFramework;
+using System;
+
+namespace nanoFramework.Json.Test
+{
+    [TestClass]
+    public class DateTimeExtensionsTests
+    {
+        [TestMethod]
+        [DataRow("19990101T000000")]
+        [DataRow("20001120T221530")]
+        [DataRow("20250706T005433")]
+        [DataRow("16010101T000000")]
+        [DataRow("30001231T235958")]
+        public void FromiCalendar_LocalTime_ShouldNotBeMaxValue(string iCal)
+        {
+            var act = DateTimeExtensions.FromiCalendar(iCal);
+
+            Assert.AreNotEqual(DateTime.MaxValue, act);
+        }
+
+        [TestMethod]
+        [DataRow("19990101T000000Z")]
+        [DataRow("20001120T221530Z")]
+        [DataRow("20250706T005433Z")]
+        [DataRow("16010101T000000Z")]
+        [DataRow("30001231T235958Z")]
+        public void FromiCalendar_UtcTime_ShouldNotBeMaxValue(string iCal)
+        {
+            var act = DateTimeExtensions.FromiCalendar(iCal);
+
+            Assert.AreNotEqual(DateTime.MaxValue, act);
+        }
+
+        [TestMethod]
+        [DataRow("12345678901234567890")]
+        [DataRow("3333333333333333")]
+        [DataRow("444444444444444")]
+        [DataRow("12345678T901234")]
+        [DataRow("000000000000000")]
+        [DataRow("test")]
+        [DataRow("test19990101T000000Z")]
+        [DataRow("test0101T000000Z")]
+        [DataRow("test19990101T000000")]
+        [DataRow("test0101T000000")]
+        [DataRow("_!123@1903$#*((")]
+        public void FromiCalendar_NotATime_ShuldReturnMaxValue(string iCal)
+        {
+            var act = DateTimeExtensions.FromiCalendar(iCal);
+
+            Assert.AreEqual(DateTime.MaxValue, act);
+        }
+    }
+}

--- a/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
+++ b/nanoFramework.Json.Test/nanoFramework.Json.Test.nfproj
@@ -49,6 +49,7 @@
     <Compile Include="Converters\FloatConverterTests.cs" />
     <Compile Include="Converters\DoubleConverterTests.cs" />
     <Compile Include="Configuration\JsonCustomTypeTests.cs" />
+    <Compile Include="DateTimeExtensionsTests.cs" />
     <Compile Include="JsonDeserializationArraysTests.cs" />
     <Compile Include="JsonSettingsTests.cs" />
     <Compile Include="JsonThreadSafeTests.cs" />

--- a/nanoFramework.Json/TimeExtensions.cs
+++ b/nanoFramework.Json/TimeExtensions.cs
@@ -55,6 +55,11 @@ namespace nanoFramework.Json
                 time = result;  // localtime
             }
 
+            if (time.Length < 15)
+            {
+                return DateTime.MaxValue;
+            }
+
             // We now have the time string to parse, and we'll adjust
             // to UTC or timezone after parsing
             string year = time.Substring(0, 4);
@@ -65,43 +70,56 @@ namespace nanoFramework.Json
             string second = time.Substring(13, 2);
 
             // Check if any of the date time parts is non-numeric
-            if (!IsNumeric(year))
+            if (!int.TryParse(year, out int intYear) ||
+                intYear < DateTime.MinValue.Year ||
+                intYear > DateTime.MaxValue.Year)
             {
                 return DateTime.MaxValue;
             }
-            else if (!IsNumeric(month))
+            if (!int.TryParse(month, out int intMonth) ||
+                intMonth < DateTime.MinValue.Month ||
+                intMonth > DateTime.MaxValue.Month)
             {
                 return DateTime.MaxValue;
             }
-            else if (!IsNumeric(day))
+            if (!int.TryParse(day, out int intDay) ||
+                intDay < DateTime.MinValue.Day ||
+                intDay > DateTime.MaxValue.Day ||
+                intDay > DateTime.DaysInMonth(intYear, intMonth))
             {
                 return DateTime.MaxValue;
             }
-            else if (!IsNumeric(hour))
+            if (!int.TryParse(hour, out int intHour) ||
+                intHour < DateTime.MinValue.Hour ||
+                intHour > DateTime.MaxValue.Hour)
             {
                 return DateTime.MaxValue;
             }
-            else if (!IsNumeric(minute))
+            if (!int.TryParse(minute, out int intMinute) ||
+                intMinute < DateTime.MinValue.Minute ||
+                intMinute > DateTime.MaxValue.Minute)
             {
                 return DateTime.MaxValue;
             }
-            else if (!IsNumeric(second))
+            if (!int.TryParse(second, out int intSecond) ||
+                intSecond < DateTime.MinValue.Second ||
+                intSecond > DateTime.MaxValue.Second)
             {
                 return DateTime.MaxValue;
             }
 
             DateTime dt = new(
-                Convert.ToInt32(year),
-                Convert.ToInt32(month),
-                Convert.ToInt32(day),
-                Convert.ToInt32(hour),
-                Convert.ToInt32(minute),
-                Convert.ToInt32(second));
+                intYear,
+                intMonth,
+                intDay,
+                intHour,
+                intMinute,
+                intSecond);
 
             if (utc)
             {
                 // Convert the Kind to DateTimeKind.Utc
-                dt = new DateTime(0, DateTimeKind.Utc).AddTicks(dt.Ticks);
+                dt = new DateTime(dt.Ticks, DateTimeKind.Utc);
             }
             else if (tzid)
             {


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description

- In the iCal parser (`DateTimeExtensions.FromiCalendar`), before creating a DateTime, the constructor parameters are now validated. Year, month, day, hour, minutes, seconds. If at least one parameter is out of bounds or is not a number, DateTime.MaxValue is returned.
- In the iCal parser (`DateTimeExtensions.FromiCalendar`), when converting a date to UTC, DateTime is now initialized with a ticks count = ticks from the existing date. Previously, date was initialized with zero ticks, and then ticks from existing date were added to it. Previously, this led to an exception, since initialization with zero ticks actually resulted in DateTime.MinValue = 1600-01-01 00:00:00 being created. If you then add ticks from 2025 to such a date, for example, you get a date from 3625 and this value is outside DateTime range since nanoFramework has a limitation, the year of DateTime cannot be >= 3001

## Motivation and Context

I noticed that when trying to deserialize a string containing many digits (18 or more), I often see exceptions in the debug output console, but this does not interfere with deserialization as such. After investigating, I found that the problem occurs when `JsonConvert` tries to figure out whether string can be a date in iCal or vCal format.

Inside this code, there is an attempt to convert string, if it is numeric, into a date, passing each individual parameter from the year to the seconds as an integer number, but before passing numbers to DateTime constructor, it was not checked before - and whether these numbers can be a year, month, day, and so on. Thus, for example, it could try to create a date with a month = 99.

In addition, there was another bug. It consists in the fact that if at the end of iCal string date there is Z letter, i.e. pointer to time in UTC format, first it creates `MinValue` date with `DateTimeKind.UTC`, and then ticks from date already obtained at the previous stage were added to created MinValue date. This led to an error, because `DateTime.MinValue` in `nanoFramework` = 1600-01-01, not a first year, as in the "big .NET"

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Unit tests were written to test the changes, most of which were not passed before the changes were made. After I fixed bugs, I ran the tests again and they passed.

I did not test the changes on real hardware.

I did not run benchmark tests.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
