### PR TITLE
Fix `TimeSpanConverter.ToJson`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
     - template: azure-pipelines-templates/class-lib-build.yml@templates
       parameters:
         sonarCloudProject: 'nanoframework_lib-nanoFramework.Json'
-        runUnitTests: false
+        runUnitTests: true
         unitTestRunsettings: '$(System.DefaultWorkingDirectory)\.runsettings'
         usePreviewBuild: true
 

--- a/nanoFramework.Json/Converters/TimeSpanConverter.cs
+++ b/nanoFramework.Json/Converters/TimeSpanConverter.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Text;
 
 namespace nanoFramework.Json.Converters
 {
@@ -12,7 +13,63 @@ namespace nanoFramework.Json.Converters
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
-        public string ToJson(object value) => $"\"{value}\"";
+        public string ToJson(object value) => "\"" + FormatTimeSpan((TimeSpan)value) + "\"";
+
+        private static string FormatTimeSpan(TimeSpan ts)
+        {
+            var isNegative = ts < TimeSpan.Zero;
+            if (isNegative)
+            {
+                ts = ts.Negate();
+            }
+
+            var subSecondTicks = (int)(ts.Ticks % TimeSpan.TicksPerSecond);
+            var hasDays = ts.Days != 0;
+            var hasSubSecond = subSecondTicks != 0;
+
+            var sb = new StringBuilder();
+
+            if (isNegative)
+            {
+                sb.Append('-');
+            }
+
+            if (hasDays)
+            {
+                sb.Append(ts.Days.ToString());
+                sb.Append('.');
+            }
+
+            sb.Append(Pad2(ts.Hours));
+            sb.Append(':');
+            sb.Append(Pad2(ts.Minutes));
+            sb.Append(':');
+            sb.Append(Pad2(ts.Seconds));
+
+            if (hasSubSecond)
+            {
+                sb.Append('.');
+                sb.Append(Pad7(subSecondTicks));
+            }
+
+            return sb.ToString();
+        }
+
+        private static string Pad2(int value)
+        {
+            return value < 10 ? "0" + value.ToString() : value.ToString();
+        }
+
+        private static string Pad7(int value)
+        {
+            var s = value.ToString();
+            while (s.Length < 7)
+            {
+                s = "0" + s;
+            }
+
+            return s;
+        }
 
         /// <summary>
         /// <inheritdoc/>

--- a/nanoFramework.Json/Converters/TimeSpanConverter.cs
+++ b/nanoFramework.Json/Converters/TimeSpanConverter.cs
@@ -20,7 +20,15 @@ namespace nanoFramework.Json.Converters
             var isNegative = ts < TimeSpan.Zero;
             if (isNegative)
             {
-                ts = ts.Negate();
+                // Special case: TimeSpan.MinValue cannot be negated, so handle it separately
+                if (ts == TimeSpan.MinValue)
+                {
+                    ts = new TimeSpan(long.MaxValue);
+                }
+                else
+                {
+                    ts = ts.Negate();
+                }
             }
 
             var subSecondTicks = (int)(ts.Ticks % TimeSpan.TicksPerSecond);


### PR DESCRIPTION
## Description
- Add custom FormatTimeSpan() method to replace TimeSpan.ToString() which has no formatted output.
- Enabled unit tests.

## Motivation and Context
- Fixes implementation of TimeSpanConverter. Failing unit tests were being hidden by error in test framework processor (now fixed).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Local running unit tests.

## Screenshots<!-- (IF APPROPRIATE): -->
<img width="506" height="96" alt="image" src="https://github.com/user-attachments/assets/05b1cac5-6d8a-4c88-bfc0-9d85b5ca929b" />

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
